### PR TITLE
自定义输出_翻译按键的双击功能

### DIFF
--- a/config_code.py
+++ b/config_code.py
@@ -1,0 +1,47 @@
+class translation_format:
+    # 双击离线翻译按键的输出格式
+    config_code_offline = f'''
+keyboard.write(offline_translated_text)
+keyboard.write(" (")
+keyboard.write(text)
+keyboard.write(")")
+    '''
+
+    # 双击在线翻译按键的输出格式
+    config_code_online = f'''
+keyboard.write(online_translated_text)
+keyboard.write(" (")
+keyboard.write(text)
+keyboard.write(")")
+    '''
+
+
+# 常用要素
+"""
+text : 初始语音文字(简体中文)
+traditional_text : 繁体中文
+offline_translated_text : 离线翻译文字
+online_translated_text : 在线翻译文字
+keyboard.write("[") : 符号 [
+keyboard.press_and_release('enter') :  模拟按下以及弹起 回车按键
+"""
+
+"""
+# 这是第一个例子:
+keyboard.write(text)
+keyboard.press_and_release('enter')
+keyboard.write(offline_translated_text)
+
+# 这是第一个例子的输出:
+这是中文
+It's Chinese.
+
+# 这是第2个例子:
+keyboard.write(offline_translated_text)
+keyboard.write(" [")
+keyboard.write(traditional_text)
+keyboard.write("]")
+
+# 这是第2个例子的输出:
+It's Chinese. [這是中文]
+"""

--- a/util/client_recv_result.py
+++ b/util/client_recv_result.py
@@ -2,6 +2,7 @@ import json
 
 import opencc
 import websockets
+import keyboard
 
 from config import ClientConfig as Config
 from util.client_check_websocket import check_websocket
@@ -11,6 +12,7 @@ from util.client_rename_audio import rename_audio
 from util.client_strip_punc import strip_punc
 from util.client_type_result import type_result
 from util.client_write_md import write_md
+from config_code import translation_format
 
 if not Cosmic.transcribe_subtitles:
     from util.client_translate_offline import translate_offline
@@ -94,10 +96,16 @@ async def recv_result():
 
             # 打字
             if offline_translate_done:
-                await type_result(offline_translated_text)
+                if Cosmic.opposite_state:
+                    exec(translation_format.config_code_offline)
+                else:
+                    await type_result(offline_translated_text)
                 offline_translate_done = False
             elif online_translate_done:
-                await type_result(online_translated_text)
+                if Cosmic.opposite_state:
+                    exec(translation_format.config_code_online)
+                else:
+                    await type_result(online_translated_text)
                 online_translate_done = False
             elif convert_to_traditional_chinese_done:
                 # 根据'简/繁'转换设定,来选择输出内容的逻辑


### PR DESCRIPTION
翻译按键的双击功能:

- 使用了 `exec` 的函数
- 根据 `config_code.py` 的设定格式进行输出
