### PR TITLE
2025.09 功能优化与问题修复汇总

### DIFF
--- a/util/client_recv_result.py
+++ b/util/client_recv_result.py
@@ -98,17 +98,20 @@ async def recv_result():
                 online_translate_done = False
             elif convert_to_traditional_chinese_done:
                 # 根据'简/繁'转换设定,来选择输出内容的逻辑
-                match Config.convert_to_traditional_chinese_main:
-                    case "繁":
-                        if Cosmic.opposite_state:
-                            await type_result(text)
-                        else:
-                            await type_result(traditional_text)
-                    case _:
-                        if Cosmic.opposite_state:
-                            await type_result(traditional_text)
-                        else:
-                            await type_result(text)
+                if Config.enable_double_click_opposite_state:
+                    match Config.convert_to_traditional_chinese_main:
+                        case "繁":
+                            if Cosmic.opposite_state:
+                                await type_result(text)
+                            else:
+                                await type_result(traditional_text)
+                        case _:
+                            if Cosmic.opposite_state:
+                                await type_result(traditional_text)
+                            else:
+                                await type_result(text)
+                else:
+                    await type_result(text)
                 convert_to_traditional_chinese_done = False
             Cosmic.opposite_state = False
     except websockets.ConnectionClosedError:

--- a/util/client_shortcut_handler.py
+++ b/util/client_shortcut_handler.py
@@ -331,6 +331,7 @@ def hold_mode(e: keyboard.KeyboardEvent):
     global \
         task, \
         double_clicked, \
+        last_time_pressed, \
         last_time_released, \
         hold_mode_first_time_cancel_task, \
         unpause_needed
@@ -349,6 +350,8 @@ def hold_mode(e: keyboard.KeyboardEvent):
                     unpause_needed = True
 
     if e.event_type == "down" and not Cosmic.on:
+        # 标记最后按下的时间
+        last_time_pressed = time.time()
         # 根據上一次是否短時間內(`is_short_duration`)按下錄音鍵,來判斷是否需要輸出 `簡/繁`
         if double_clicked and Config.enable_double_click_opposite_state:
             Cosmic.opposite_state = not Cosmic.opposite_state
@@ -363,11 +366,11 @@ def hold_mode(e: keyboard.KeyboardEvent):
         # 记录开始时间
         launch_task()
 
-    elif e.event_type == "up":
+    if e.event_type == "up":
         # 标记最后弹起的时间
         last_time_released = time.time()
         # 记录持续时间，并标识录音线程停止向队列放数据
-        duration = time.time() - Cosmic.on
+        duration = time.time() - last_time_pressed
         # 取消或停止任务
         if duration < Config.threshold and not double_clicked:
             hold_mode_first_time_cancel_task = True

--- a/util/client_shortcut_handler.py
+++ b/util/client_shortcut_handler.py
@@ -71,17 +71,17 @@ def unmute_all_sessions():
             volume = session.SimpleAudioVolume
             volume.SetMute(0, None)
 
+
 def restore_audio_playing():
     # 恢復音频的播放
     global restore_audio_playing_needed, saved_result_for_restore_audio_playing_needed
     # 处理音频暂停相关逻辑
-    print(f"restore_audio_playing  1. restore_audio_playing_needed:{restore_audio_playing_needed}")
     restore_audio_playing_needed = saved_result_for_restore_audio_playing_needed
-    print(f"restore_audio_playing  2. restore_audio_playing_needed:{restore_audio_playing_needed}")
+
     if Config.pause_other_audio and restore_audio_playing_needed:
         keyboard.send("play/pause")
-        print(f"restore_audio_playing  3. restore_audio_playing_needed:{restore_audio_playing_needed}")
         restore_audio_playing_needed  = False
+
 
 def translate_needed():
     # 确认是否需要翻译
@@ -153,33 +153,20 @@ def launch_task():
                 # 试过的时间: 0.2✘; 0.3✘; 0.4✔; 0.5✔;1✔
                 time.sleep(0.4)
                 
-        print(f"is_short_duration: {is_short_duration}")
         if process_name := audio_playering_app_name():
-            print(f"launch  1. Audio is currently playering by {process_name} .")
-            print(f"launch  1. restore_audio_playing_needed:{restore_audio_playing_needed}")
-            if process_name != "ffplay.exe":
+            if process_name != "ffplay.exe" :
                 keyboard.send("play/pause")
-                # if process_name != None:
                 restore_audio_playing_needed  = True
-                print(f"launch  A. process_name: {process_name} .")
-            # # 恢復原狀：修復因 "saved_result_for_restore_audio_playing_needed" 變量導致播放器誤播的狀況(在已經本身停播的情況下)。
-            # if process_name is None:
-            #     print(f"launch  B. process_name: {process_name} .")
-            #     saved_result_for_restore_audio_playing_needed = False
 
             if not is_short_duration:
                 saved_result_for_restore_audio_playing_needed = restore_audio_playing_needed
-    print(f"launch  2. Audio is currently playering by {process_name} .")
-    print(f"launch  2. restore_audio_playing_needed:{restore_audio_playing_needed}")
 
     # 恢復原狀：修復因 "saved_result_for_restore_audio_playing_needed" 變量導致播放器誤播的狀況(在已經本身停播的情況下)。
-    if process_name is None:
-        print(f"launch  B. process_name: {process_name} .")
+    if process_name is None and not Config.hold_mode:
         saved_result_for_restore_audio_playing_needed = False
         restore_audio_playing_needed = False
-        print(f"launch  3. restore_audio_playing_needed:{restore_audio_playing_needed}")
-    # 通知录音线程可以向队列放数据了
 
+    # 通知录音线程可以向队列放数据了
     Cosmic.on = t1
 
     # 打印动画：正在录音
@@ -194,18 +181,6 @@ def launch_task():
 
 
 def cancel_task():
-    # # 恢復音频的播放
-    # global restore_audio_playing_needed 
-    # # 处理音频暂停相关逻辑
-    # print(f"cancel  1. restore_audio_playing_needed:{restore_audio_playing_needed}")
-    # restore_audio_playing_needed = saved_result_for_restore_audio_playing_needed
-    # print(f"cancel  2. restore_audio_playing_needed:{restore_audio_playing_needed}")
-    # if Config.pause_other_audio and restore_audio_playing_needed:
-    #     keyboard.send("play/pause")
-    #     restore_audio_playing_needed  = False
-
-
-
     # 通知停止录音，关掉滚动条
     Cosmic.on = False
     status.stop()
@@ -250,18 +225,7 @@ def finish_task():
 
     if shutil.which("ffplay") and Config.play_stop_music:
         from util.client_play_music import play_music
-
         play_music(Config.stop_music_path, Config.stop_music_volume)
-
-    # # 恢復音频的播放
-    # global restore_audio_playing_needed 
-    # # 处理音频暂停相关逻辑
-    # restore_audio_playing_needed = saved_result_for_restore_audio_playing_needed
-    # print(f"Finish.1 restore_audio_playing_needed:{restore_audio_playing_needed}")
-    # if Config.pause_other_audio and restore_audio_playing_needed :
-    #     keyboard.send("play/pause")
-    #     restore_audio_playing_needed  = False
-    # print(f"Finish.2 restore_audio_playing_needed:{restore_audio_playing_needed}")
 
     if Config.only_enable_microphones_when_pressed_record_shortcut:
         # 结束音频流
@@ -285,17 +249,16 @@ def click_mode(e: keyboard.KeyboardEvent):
 
     # 4. 为了解决在 Windows 下按键会自动重复的问题 : key_pressed 变量用于追踪按键是否已经被按下并记录时间。当按键第一次被按下时，记录时间并将 key_pressed 设为 True，防止重复记录时间。当按键释放时，将 key_pressed 重新设为 False，允许下一次按键记录新的时间。
     
-    # - [x] Bug6: 20250918: click_mode : "double_clicked" 变量 在此处函数中 改为常駐, 他会导致 Config.enable_double_click_opposite_state 这个配置项失效， 需要修正
-            # 解决方法: client_recv_result.py : 把判断变量的位置改放在 async def recv_result() 后面。 同时把 client_shortcut_handler.py 里面的所有Config.enable_double_click_opposite_state 取消掉 。 
+    # - [x] Bug6: 20250918: click_mode : "double_clicked" 改为常驻 → 导致 Config.enable_double_click_opposite_state 失效。
+            # 解决方法: client_recv_result.py → 判断变量放到 async def recv_result() 后；client_shortcut_handler.py → 移除所有 Config.enable_double_click_opposite_state。
 
-    # - [x] Bug4: 20250919: click_mode : "Shift + double_clicked or double_clicked" 有機會導致恢復音頻播放失敗.. 原因不明，需要再跟进。 觀察: 先是停下播放之後，然後輸出文字後聽到一些聲音，但是很快就又停止了。 
-            # 解决方法-Bug4: 函数: "elif (double_clicked and is_short_duration)" : 這裏的函數 "restore_audio_playing()" 不應該加進來，不需要。 
+    # - [x] Bug4: 20250919: click_mode : "Shift + double_clicked / double_clicked" 可能导致恢复播放失败。
+            # 解决方法-Bug4: 在 "elif (double_clicked and is_short_duration)" 中移除 restore_audio_playing()。
 
-    # - [ ] 潜在的改善点: 20250924: 假如有两个应用在运行, 其中第1个在播放，第2个在暂停, 那么我进行录音，第一个会被暂停，而第2个在录音期间依然会被播放(靜音), 这不符合最初暂停所有的应用的设想. 
-        # 解决思路是根据每一个应用侦测它的播放状态, 最终根据此状态依次针对每一个应用进行判断是否恢复播放.但是需要解决的是:
-            # 1. 是否能指定某一个应用进行暂停或者播放？
-            # 2. 如何判断某一个应用是否正在播放？audio_playering_app_name() 给出的资讯需要放入数组中.
-        
+    # - [ ] 潜在改善点: 20250924: 假如有两个应用在运行, 其中第1个在播放，第2个在暂停, 那么我进行录音，第一个会被暂停，而第2个在录音期间依然会被播放(靜音)，不符合“暂停所有应用”的设想。
+        # 思路: 
+            # 1. 能否指定某应用暂停/播放？
+            # 2. 如何判断应用是否在播放？需将 audio_playering_app_name() 的结果存入数组逐一判断。
 
     global \
         last_time_pressed, \
@@ -333,7 +296,6 @@ def click_mode(e: keyboard.KeyboardEvent):
             # 判定为`長按`，发送原來的按键功能
             keyboard.send(Config.speech_recognition_shortcut)
             key_pressed = False
-            print(f"A")
             return
 
         # 任务不在进行中, 且不判定为`短击`, 就开始任务, 同时标记 任务在进行中狀态
@@ -347,11 +309,9 @@ def click_mode(e: keyboard.KeyboardEvent):
                 Config.hold_mode,
             )
             launch_task()
-            # `double_clicked`变量 在此处函数中 改为常駐 因此不需要以下的config判断
-            # if Config.enable_double_click_opposite_state:
+
             double_clicked = True
             key_pressed = False
-            print(f"B")
             return
 
         # 任务在进行中, 且不判定为`短击`, 就结束和完成任务
@@ -365,20 +325,16 @@ def click_mode(e: keyboard.KeyboardEvent):
                 Config.hold_mode,
             )
 
-            # if Config.enable_double_click_opposite_state:
             double_clicked = False
             key_pressed = False
 
             # 恢復音频的播放
-            print(f"C1")
             restore_audio_playing()
-            print(f"C2")
             return
 
         # 任务在进行中, 且为`短击`, 判定爲需要輸出 `簡/繁`, 并且结束函数
         elif (
             double_clicked and is_short_duration
-            # and Config.enable_double_click_opposite_state
         ):
             translate_needed()
             send_signal_to_hint_while_recording(
@@ -391,12 +347,6 @@ def click_mode(e: keyboard.KeyboardEvent):
 
             Cosmic.opposite_state = not Cosmic.opposite_state
             key_pressed = False
-
-            # 恢復音频的播放
-            print(f"D1")
-            # 這裏的函數 "restore_audio_playing()" 不應該加進來，不需要。 
-            # restore_audio_playing()
-            print(f"D2")
             # return
 
         # print(f'世界的尽头!')
@@ -404,187 +354,35 @@ def click_mode(e: keyboard.KeyboardEvent):
 
 # ======================长按模式==================================
 
-'''
-def hold_mode(e: keyboard.KeyboardEvent):
-    """像对讲机一样，按下录音，松开停止"""
-    global \
-        task, \
-        double_clicked, \
-        last_time_released, \
-        hold_mode_first_time_cancel_task, \
-        restore_audio_playing_needed 
-
-    # 計算是否屬於短時間內按下`錄音鍵`
-    is_short_duration = (
-        True if time.time() - last_time_released < Config.threshold else False
-    )
-
-    # 短時間內,按下第二次錄音鍵判定爲需要輸出 `簡/繁`
-    if is_short_duration and Config.enable_double_click_opposite_state:
-        double_clicked = True
-        if Config.pause_other_audio and not restore_audio_playing_needed :
-            if process_name := audio_playering_app_name():
-                if process_name != "ffplay.exe":
-                    restore_audio_playing_needed  = True
-
-    if e.event_type == "down" and not Cosmic.on:
-        # 根據上一次是否短時間內(`is_short_duration`)按下錄音鍵,來判斷是否需要輸出 `簡/繁`
-        if double_clicked and Config.enable_double_click_opposite_state:
-            Cosmic.opposite_state = not Cosmic.opposite_state
-        translate_needed()
-        send_signal_to_hint_while_recording(
-            True,
-            is_short_duration,
-            Cosmic.offline_translate_needed,
-            Cosmic.online_translate_needed,
-            Config.hold_mode,
-        )
-        # 记录开始时间
-        launch_task()
-
-    elif e.event_type == "up":
-        # 标记最后弹起的时间
-        last_time_released = time.time()
-        # 记录持续时间，并标识录音线程停止向队列放数据
-        duration = time.time() - Cosmic.on
-        # 取消或停止任务
-        if duration < Config.threshold and not double_clicked:
-            hold_mode_first_time_cancel_task = True
-
-            cancel_task()
-
-        else:
-            finish_task()
-            # 松开快捷键后，再按一次，恢复 CapsLock 或 Shift 等按键的状态
-            if not double_clicked and Config.restore_key:
-                time.sleep(0.01)
-                keyboard.send(Config.speech_recognition_shortcut)
-            # 恢复輸出 `簡/繁` 原来的狀態
-            if Config.enable_double_click_opposite_state:
-                double_clicked = False
-
-        send_signal_to_hint_while_recording(
-            False,
-            is_short_duration,
-            Cosmic.offline_translate_needed,
-            Cosmic.online_translate_needed,
-            Config.hold_mode,
-        )
-'''
-'''
-def hold_mode(e: keyboard.KeyboardEvent):
-    """像对讲机一样，按下录音，松开停止"""
-    global task, double_clicked, last_time_released, key_pressed, last_time_pressed, is_short_duration
-    global hold_mode_first_time_cancel_task, restore_audio_playing_needed 
-
-    # 处理按键按下事件
-    if e.event_type == keyboard.KEY_DOWN:
-        # 仅在未按下状态时处理按下事件，防止重复触发
-        if not key_pressed:
-            key_pressed = True  # 标记为已按下
-            last_time_pressed = time.time()  # 统一获取当前时间，避免多次调用
-            # 计算是否属于短时间内按下录音键
-            is_short_duration = (last_time_pressed - last_time_released) < Config.threshold
-
-            # 处理双击逻辑
-            if is_short_duration and Config.enable_double_click_opposite_state:
-                double_clicked = True
-                _handle_audio_pause()
-
-            _handle_key_down(double_clicked, is_short_duration)
-    
-    # 处理按键松开事件（单独判断，不被key_pressed状态阻塞）
-    elif e.event_type == keyboard.KEY_UP:
-        # 仅在已按下状态时处理松开事件
-        if key_pressed:
-            last_time_released = time.time()  # 统一获取当前时间，避免多次调用
-            # is_short_duration = (last_time_pressed - last_time_released) < Config.threshold
-            _handle_key_up(last_time_pressed, is_short_duration)
-            key_pressed = False  # 标记为未按下
-
-
-def _handle_audio_pause():
-    global restore_audio_playing_needed 
-    """处理音频暂停相关逻辑"""
-    if Config.pause_other_audio and not restore_audio_playing_needed :
-        process_name = audio_playering_app_name()
-        if process_name and process_name != "ffplay.exe":
-            restore_audio_playing_needed  = True
-
-
-def _handle_key_down(double_clicked, is_short_duration):
-    """处理按键按下时的逻辑"""
-    # 处理双击切换简/繁状态
-    if double_clicked and Config.enable_double_click_opposite_state:
-        Cosmic.opposite_state = not Cosmic.opposite_state
-    
-    translate_needed()
-    send_signal_to_hint_while_recording(
-        True,
-        is_short_duration,
-        Cosmic.offline_translate_needed,
-        Cosmic.online_translate_needed,
-        Config.hold_mode,
-    )
-    # 启动录音任务
-    launch_task()
-
-
-def _handle_key_up(last_time_pressed, is_short_duration):
-    """处理按键松开时的逻辑"""
-    global last_time_released, hold_mode_first_time_cancel_task, double_clicked
-    
-    # 更新最后松开时间
-    # last_time_released = last_time_pressed
-    # duration = last_time_released - last_time_pressed
-
-    # 处理任务取消或完成
-    if is_short_duration and not double_clicked:
-        hold_mode_first_time_cancel_task = True
-        cancel_task()
-    else:
-        finish_task()
-        # 恢复按键状态
-        if not double_clicked and Config.restore_key:
-            time.sleep(0.01)
-            keyboard.send(Config.speech_recognition_shortcut)
-        # 重置双击状态
-        if Config.enable_double_click_opposite_state:
-            double_clicked = False
-
-    # 发送录音结束信号
-    send_signal_to_hint_while_recording(
-        False,
-        is_short_duration,
-        Cosmic.offline_translate_needed,
-        Cosmic.online_translate_needed,
-        Config.hold_mode,
-    )
-'''
 
 def hold_mode(e: keyboard.KeyboardEvent):
     """像对讲机一样，按下录音，松开停止"""
-    # - [x] 改進: 20250918: 增加了 key_pressed 变量用于追踪按键是否已经被按下， 以免某些函数会被重复触发。
-    # - [x] 改進: 20250918: 在此函数中, 取消了 Cosmic.on 的运用, 改为了 last_time_released & last_time_pressed 变量来进行时间的记录和计算.
+    # - [x] 改進: 20250918: 增加 key_pressed 变量避免函数重复触发。
+    # - [x] 改進: 20250918: 去掉 Cosmic.on，改用 last_time_released & last_time_pressed 记录时间。
 
-    # - [x] Bug1: 20250918: 在Hold Mode下, 1. 如果按下和弹起`錄音鍵` 单次的時間小于< Config.threshold 以及 2.双击的功能, 会导致播放中的浏览器或者音乐播放器 *不会恢复播放* 的状态。
-        # - [x]  解決方法-Bug1 20250919: 2.双击的功能: 不会回复播放的原因是因为第一次弹起來的時候, 恢復播放的时候会有一段空档期, 这段期间使用电平侦测-是否有应用在播放的方法就会失效。 解決方法是增加了 saved_result_for_restore_audio_playing_needed 变量来保存第一次的状态。 
-        # - [x]  解決方法-Bug1 20250919: 1.小于< Config.threshold: 单次按下和弹起录音键 ， 就会快速的停止和恢复播放。但是这两个指令间隔的时间太短，导致恢复的命令被吞掉了，所以把恢复的命令放到最后，让他有更多的时间执行。 同时`def cancel_task()` 和 `def finish_task()` 里面的恢复播放命令被取消了，放到独立的函數里执行。 
+    # - [x] Bug1: 20250918: Hold Mode 下
+    #       1. 单次按下/弹起录音键 < Config.threshold
+    #       2. 双击录音键
+    #     → 播放无法恢复。
+        # - [x] 解決方法-Bug1 20250919: 双击 → 增加 saved_result_for_restore_audio_playing_needed 保存状态。
+        # - [x] 解決方法-Bug1 20250919: < threshold → 恢复命令延后执行，独立成函数。
 
-    # - [?] Bug2: 20250918: 在上述的改动后 ，需要继续观察是否还会存在"任务顺序错乱"的情况。
-    # - [x] Bug3: 20250918: holdmode = true: shift + 录音键(双击) 失效了, 变成了输出简体中文 。 holdmode = false: 正常。
-        # 解決方法-Bug3: 20250919: Config.enable_double_click_opposite_state= false: 修改成这个之后，他居然可以使用 "shift +双击" = 英文输出了 (没有删除这个变量"enable_double_click_opposite_state"之前)
-        # 解決方法-Bug3: 20250919: 把 hold_mode() 里面的 Config.enable_double_click_opposite_state 删除掉, "shift +双击" = 中文输出， 看来BUG和这个 enable_double_click_opposite_state 有关， 需要继续解决。 (click_mode 没有这个问题)
-        # 解決方法-Bug3: 20250924: 第二次按键抬起之前还"T3. offline_translate_needed:True", 第二次按键抬起之后"O1. offline_translate_needed:False", 完全不知道为什么有这个转变，因为这两个行动之间是没有任何关于"offline_translate_needed"的行动, 哪怕有转变之后再侦测一次"translate_needed()" 依然是"offline_translate_needed:False", 像是"shift按键" 被强行抬起了一样。 解决方法是引入"saved_result_for_offline_translate_needed"的变量储存第一次的状态。 
-        # - [?] 原因-Bug3: 20250924: 第一次按键抬起来的时候就会触发"恢复大小字母按键 keyboard.send(Config.speech_recognition_shortcut)" ， 导致该按键会被抬起，从而不能识别为按下, 因此，从这个动作之后的"translate_needed()"就会一直被认为没有按下"shift"。 20250924: 再想了想, 这个原因应该是不对的， 因为抬起的应该是"cap lock", 除非他會牵连這個 shift 按鍵？20250924: 这个牵连是有可能的, 因为 "shift" 键 = 临时切换大小写状态。 需要再继续寻找原因。。。
+    # - [?] Bug2: 20250918: 改动后需观察是否仍有任务顺序错乱。
 
-    # - [x] 更新 20250919: 需要更新最新版本的 "sherpa-onnx-sense-voice-zh-en-ja-ko-yue-int8-2025-09-09"
-        # 解決方法-更新: 20250924: 更新成功了, 但是沒發現這個新模型有標點功能，因此需要加載額外的標點功能模型 。 最終的感覺不如舊的模型好，因此還原 。 
+    # - [x] Bug3: 20250918: holdmode=true 时 shift+录音键(双击) 失效，输出简体中文；holdmode=false 正常。
+        # 解決方法-Bug3: 20250919: 修改 Config.enable_double_click_opposite_state=false → 可英文输出。
+        # 解決方法-Bug3: 20250919: 删除 hold_mode() 内的 enable_double_click_opposite_state → 变为中文输出，问题与该变量相关。
+        # 解決方法-Bug3: 20250924: 引入 saved_result_for_offline_translate_needed 保存状态，避免 shift 被误判抬起。
+        # - [?] 原因-Bug3: 可能与 shift/caps lock 状态牵连有关，需继续确认。
 
-    # - [?] Bug5: 20250919: hold_mode: 录音键(双击) 有機會導致不會恢復播放(原本已在播放)
-        # 观察-Bug5: def launch_task(): "# 录音时暂停其他音频播放 且 有音频正在播放" 放回到中間之後, 只測試出一次沒有恢復播放的情況。 需要繼續觀察.. 
-        # 观察-Bug5: 20250924: 第一次按下会暂停播放，抬起就会恢复播放, 然后短时间内第二次按下会静音，这里本应是需要暂停的, 但是会继续播放(这里不符合预想的结果,推测是因为有三次的快速操作,导致第三次的动作被吞掉了), 跟着第二次抬起(已经过了一段时间),就会被错误的暂停了(restore_audio_playing_needed = true)。 
-        # 解决方法-Bug5: 20250924: 在这里 def launch_task() 加上一个, 但凡是快速按下第二次(is_short_duration)就会延迟一段时间. 逻辑上以及实际测试只有 hold_mode 会应用这个延迟。 
+    # - [x] 更新 20250919: 更新 "sherpa-onnx-sense-voice-zh-en-ja-ko-yue-int8-2025-09-09"
+        # 解決方法-更新: 20250924: 新模型无标点，需额外加载；最终的效果不如旧版，已还原。
+
+    # - [x] Bug5: 20250919: hold_mode 下双击录音键可能不恢复播放。
+        # 观察-Bug5: 调整 launch_task() 暂停逻辑后，仅出现过一次，需继续观察。
+        # 观察-Bug5: 20250924: 快速三次操作导致第三次动作被吞，第二次抬起时错误暂停。
+        # 解决方法-Bug5: 20250924: 在 launch_task() 中对快速第二次按下(is_short_duration)增加延迟，仅 hold_mode 应用。
+
         
     global \
         task, \
@@ -603,24 +401,19 @@ def hold_mode(e: keyboard.KeyboardEvent):
     if e.event_type == "down":
         if not key_pressed:
             key_pressed = True  # 标记为已按下
-            print(f"1. restore_audio_playing_needed:{restore_audio_playing_needed}")
-            print(f"T1. offline_translate_needed:{Cosmic.offline_translate_needed}")
             last_time_pressed = time.time()
             # 計算是否屬於短時間內按下`錄音鍵`
             is_short_duration = (last_time_pressed - last_time_released) < Config.threshold
 
             # 短時間內,按下第二次錄音鍵判定爲需要輸出 `簡/繁`
             if is_short_duration:
-            # and Config.enable_double_click_opposite_state:
                 double_clicked = True
 
             # 处理双击切换简/繁状态
             if double_clicked:
-            # and Config.enable_double_click_opposite_state:
                 Cosmic.opposite_state = not Cosmic.opposite_state
 
             translate_needed()
-            print(f"T2. offline_translate_needed:{Cosmic.offline_translate_needed}")
             send_signal_to_hint_while_recording(
                 True,
                 is_short_duration,
@@ -632,16 +425,14 @@ def hold_mode(e: keyboard.KeyboardEvent):
             launch_task()
             saved_result_for_offline_translate_needed = Cosmic.offline_translate_needed
             saved_result_for_online_translate_needed = Cosmic.online_translate_needed
-            print(f"T3. offline_translate_needed:{Cosmic.offline_translate_needed}")
 
     elif e.event_type == "up":
         # 仅在已按下状态时处理松开事件
         if key_pressed:
-            print(f"O1. offline_translate_needed:{Cosmic.offline_translate_needed}")
             if is_short_duration:
                 Cosmic.offline_translate_needed = saved_result_for_offline_translate_needed
                 Cosmic.online_translate_needed = saved_result_for_online_translate_needed
-                print(f"O1A. offline_translate_needed:{Cosmic.offline_translate_needed}")
+
             # 标记最后弹起的时间
             last_time_released = time.time()
             # 计算按键弹起来和按下的间隔
@@ -650,21 +441,19 @@ def hold_mode(e: keyboard.KeyboardEvent):
             if duration < Config.threshold and not double_clicked:
                 hold_mode_first_time_cancel_task = True
                 cancel_task()
-                print(f"O2. offline_translate_needed:{Cosmic.offline_translate_needed}")
 
             else:
-                # translate_needed()
-                # Cosmic.offline_translate_needed = True
                 finish_task()
-                print(f"O3. offline_translate_needed:{Cosmic.offline_translate_needed}")
+
                 # 任务完成后, 还原释放案件的时间, 以免两个任务的时间间隔太短导致误判
-                # last_time_released = 0
+                last_time_released = 0
+
                 # 松开快捷键后，再按一次，恢复 CapsLock 或 Shift 等按键的状态
                 if not double_clicked and Config.restore_key:
                     # time.sleep(0.01)
                     keyboard.send(Config.speech_recognition_shortcut)
-                # 恢复輸出 `簡/繁` 原来的狀態
-                #if Config.enable_double_click_opposite_state:
+
+                # 恢复輸出 `簡/繁` 原来的狀態， 恢复这个关于翻译的变量状态
                 double_clicked = False
                 saved_result_for_offline_translate_needed = False
                 saved_result_for_online_translate_needed = False
@@ -677,11 +466,10 @@ def hold_mode(e: keyboard.KeyboardEvent):
                 Cosmic.online_translate_needed,
                 Config.hold_mode,
             )
+
             # 恢復音频的播放
             restore_audio_playing()
             key_pressed = False  # 标记为未按下
-            print(f"O4. offline_translate_needed:{Cosmic.offline_translate_needed}")
-            print(f"Last. restore_audio_playing_needed:{restore_audio_playing_needed}")
 
 # ==================== 绑定 handler ===============================
 

--- a/util/client_shortcut_handler.py
+++ b/util/client_shortcut_handler.py
@@ -268,7 +268,7 @@ def finish_task():
 # =================单击模式======================
 # 封装需要异步执行的原版 CapsLock 功能（延迟+恢复）
 async def original_capslock_function():
-    global restore_capslock_task
+    global restore_capslock_task, return_allowed
     if Config.restore_key:
         # 开始"倒数"至少0.3秒(threshold)
         await asyncio.sleep(Config.threshold)
@@ -276,6 +276,7 @@ async def original_capslock_function():
         if keyboard.is_pressed(Config.speech_recognition_shortcut):
             keyboard.send(Config.speech_recognition_shortcut)
         restore_capslock_task = None
+        return_allowed = True
 
 
 def click_mode(e: keyboard.KeyboardEvent):
@@ -288,6 +289,8 @@ def click_mode(e: keyboard.KeyboardEvent):
 
     # 3.改進點: `長按` = 进行大小写切换的功能, 需要按键抬起后才能切换;
         # - [x] 改進: 20250926: 通过异步的方法实现了原版的长按功能(至少按下0.3秒,click_mode only), 在`长按`的过程中, 按键会自动重复, 就像原来的"caps lock"自己亮起的一样。 
+        # - Bug: 20250926: 通过长按录音键后恢复原有的功能之后，立刻马上进行录音会失败
+		    # - [x] 解決方法: 引入 return_allowed 变量来引导进入return结束函数
 
     # 4. 为了解决在 Windows 下按键会自动重复的问题 : key_pressed 变量用于追踪按键是否已经被按下并记录时间。当按键第一次被按下时，记录时间并将 key_pressed 设为 True，防止重复记录时间。当按键释放时，将 key_pressed 重新设为 False，允许下一次按键记录新的时间。
     
@@ -309,10 +312,12 @@ def click_mode(e: keyboard.KeyboardEvent):
         double_clicked, \
         is_short_duration, \
         restore_audio_playing_needed, \
-        restore_capslock_task
+        restore_capslock_task, \
+        return_allowed
 
     if e.event_type == keyboard.KEY_DOWN and not key_pressed:
         key_pressed = True
+        return_allowed = False
 
         if restore_capslock_task is None:
             restore_capslock_task = asyncio.run_coroutine_threadsafe(
@@ -327,10 +332,10 @@ def click_mode(e: keyboard.KeyboardEvent):
         last_time_pressed = time.time()
 
     elif e.event_type == keyboard.KEY_UP:
-        last_time_released = time.time()
+        if restore_capslock_task is not None:
+            last_time_released = time.time()
 
         # 取消 延迟恢复原版CapsLock功能的任务
-        if restore_capslock_task is not None:
             restore_capslock_task_cancelled = restore_capslock_task.cancel()
             # if restore_capslock_task_cancelled:
             #     print("成功取消延迟的restore_capslock_task操作")
@@ -339,7 +344,7 @@ def click_mode(e: keyboard.KeyboardEvent):
             restore_capslock_task = None
 
         # 如果大于`Config.threshold`的值, 判定为`長按`, 就取消本栈启动的任务(`cancel_task()`)
-        if last_time_released - last_time_pressed >= Config.threshold and Config.restore_key:
+        if Config.restore_key and return_allowed:
             # 判定为`長按`，发送原來的按键功能
             # keyboard.send(Config.speech_recognition_shortcut)
             key_pressed = False
@@ -391,7 +396,7 @@ def click_mode(e: keyboard.KeyboardEvent):
                 Cosmic.online_translate_needed,
                 Config.hold_mode,
             )
-
+            
             Cosmic.opposite_state = not Cosmic.opposite_state
             key_pressed = False
             # return

--- a/util/client_shortcut_handler.py
+++ b/util/client_shortcut_handler.py
@@ -23,7 +23,8 @@ pool = ThreadPoolExecutor()
 pressed = False
 released = True
 event = Event()
-unpause_needed = False
+restore_audio_playing_needed  = False
+saved_result_for_restore_audio_playing_needed = False
 double_clicked = False
 is_short_duration = False
 hold_mode_first_time_cancel_task = False
@@ -68,6 +69,17 @@ def unmute_all_sessions():
             volume = session.SimpleAudioVolume
             volume.SetMute(0, None)
 
+def restore_audio_playing():
+    # 恢復音频的播放
+    global restore_audio_playing_needed, saved_result_for_restore_audio_playing_needed
+    # 处理音频暂停相关逻辑
+    print(f"restore_audio_playing  1. restore_audio_playing_needed:{restore_audio_playing_needed}")
+    restore_audio_playing_needed = saved_result_for_restore_audio_playing_needed
+    print(f"restore_audio_playing  2. restore_audio_playing_needed:{restore_audio_playing_needed}")
+    if Config.pause_other_audio and restore_audio_playing_needed:
+        keyboard.send("play/pause")
+        print(f"restore_audio_playing  3. restore_audio_playing_needed:{restore_audio_playing_needed}")
+        restore_audio_playing_needed  = False
 
 def translate_needed():
     # 确认是否需要翻译
@@ -132,14 +144,34 @@ def launch_task():
         mute_all_sessions()
 
     # 录音时暂停其他音频播放 且 有音频正在播放
-    global unpause_needed
-    if Config.pause_other_audio and not unpause_needed:
+    global restore_audio_playing_needed, saved_result_for_restore_audio_playing_needed
+    if Config.pause_other_audio and not restore_audio_playing_needed :
         if process_name := audio_playering_app_name():
-            if process_name != "ffplay.exe":
+            print(f"launch  1. Audio is currently playering by {process_name} .")
+            print(f"launch  1. restore_audio_playing_needed:{restore_audio_playing_needed}")
+            if process_name != "ffplay.exe" :
                 keyboard.send("play/pause")
-                unpause_needed = True
+                # if process_name != None:
+                restore_audio_playing_needed  = True
+                print(f"launch  A. process_name: {process_name} .")
+            # # 恢復原狀：修復因 "saved_result_for_restore_audio_playing_needed" 變量導致播放器誤播的狀況(在已經本身停播的情況下)。
+            # if process_name is None:
+            #     print(f"launch  B. process_name: {process_name} .")
+            #     saved_result_for_restore_audio_playing_needed = False
 
+            if not is_short_duration:
+                saved_result_for_restore_audio_playing_needed = restore_audio_playing_needed
+    print(f"launch  2. Audio is currently playering by {process_name} .")
+    print(f"launch  2. restore_audio_playing_needed:{restore_audio_playing_needed}")
+
+    # 恢復原狀：修復因 "saved_result_for_restore_audio_playing_needed" 變量導致播放器誤播的狀況(在已經本身停播的情況下)。
+    if process_name is None:
+        print(f"launch  B. process_name: {process_name} .")
+        saved_result_for_restore_audio_playing_needed = False
+        restore_audio_playing_needed = False
+        print(f"launch  3. restore_audio_playing_needed:{restore_audio_playing_needed}")
     # 通知录音线程可以向队列放数据了
+
     Cosmic.on = t1
 
     # 打印动画：正在录音
@@ -154,19 +186,25 @@ def launch_task():
 
 
 def cancel_task():
+    # # 恢復音频的播放
+    # global restore_audio_playing_needed 
+    # # 处理音频暂停相关逻辑
+    # print(f"cancel  1. restore_audio_playing_needed:{restore_audio_playing_needed}")
+    # restore_audio_playing_needed = saved_result_for_restore_audio_playing_needed
+    # print(f"cancel  2. restore_audio_playing_needed:{restore_audio_playing_needed}")
+    # if Config.pause_other_audio and restore_audio_playing_needed:
+    #     keyboard.send("play/pause")
+    #     restore_audio_playing_needed  = False
+
+
+
     # 通知停止录音，关掉滚动条
     Cosmic.on = False
     status.stop()
 
-    # 取消音频静音
+   # 取消音频静音
     if Config.mute_other_audio:
         unmute_all_sessions()
-
-    # 取消音频暂停
-    global unpause_needed
-    if Config.pause_other_audio and unpause_needed:
-        keyboard.send("play/pause")
-        unpause_needed = False
 
     # 发送取消任务的消息到队列
     asyncio.run_coroutine_threadsafe(
@@ -207,11 +245,16 @@ def finish_task():
 
         play_music(Config.stop_music_path, Config.stop_music_volume)
 
-    # 取消音频暂停
-    global unpause_needed
-    if Config.pause_other_audio and unpause_needed:
-        keyboard.send("play/pause")
-        unpause_needed = False
+    # # 恢復音频的播放
+    # global restore_audio_playing_needed 
+    # # 处理音频暂停相关逻辑
+    # restore_audio_playing_needed = saved_result_for_restore_audio_playing_needed
+    # print(f"Finish.1 restore_audio_playing_needed:{restore_audio_playing_needed}")
+    # if Config.pause_other_audio and restore_audio_playing_needed :
+    #     keyboard.send("play/pause")
+    #     restore_audio_playing_needed  = False
+    # print(f"Finish.2 restore_audio_playing_needed:{restore_audio_playing_needed}")
+
     if Config.only_enable_microphones_when_pressed_record_shortcut:
         # 结束音频流
         Cosmic.stream.stop()
@@ -233,14 +276,17 @@ def click_mode(e: keyboard.KeyboardEvent):
     # 3.1. 如果需要按下之后是根据按下(不需要抬起)的时间自动进行大小写切换的功能, 可以参考原来作者的代码`def count_down(e: Event):`
 
     # 4. 为了解决在 Windows 下按键会自动重复的问题 : key_pressed 变量用于追踪按键是否已经被按下并记录时间。当按键第一次被按下时，记录时间并将 key_pressed 设为 True，防止重复记录时间。当按键释放时，将 key_pressed 重新设为 False，允许下一次按键记录新的时间。
-
+    
+    # 20250918: click_mode : "double_clicked" 变量 在此处函数中 改为常駐, 他会导致 Config.enable_double_click_opposite_state 这个配置项失效， 需要修正
+    # Bug4: 20250919: click_mode : "Shift + double_clicked or double_clicked" 有機會導致恢復音頻播放失敗.. 原因不明，需要再跟进。 觀察: 先是停下播放之後，然後輸出文字後聽到一些聲音，但是很快就又停止了。 
+    # 解决方法-Bug4: 函数: "elif (double_clicked and is_short_duration)" : 這裏的函數 "restore_audio_playing()" 不應該加進來，不需要。 
     global \
         last_time_pressed, \
         last_time_released, \
         key_pressed, \
         double_clicked, \
         is_short_duration, \
-        unpause_needed
+        restore_audio_playing_needed 
 
     if e.event_type == keyboard.KEY_DOWN and not key_pressed:
         # 計算是否屬於短時間內雙击`錄音鍵`
@@ -270,6 +316,7 @@ def click_mode(e: keyboard.KeyboardEvent):
             # 判定为`長按`，发送原來的按键功能
             keyboard.send(Config.speech_recognition_shortcut)
             key_pressed = False
+            print(f"A")
             return
 
         # 任务不在进行中, 且不判定为`短击`, 就开始任务, 同时标记 任务在进行中狀态
@@ -287,6 +334,8 @@ def click_mode(e: keyboard.KeyboardEvent):
             # if Config.enable_double_click_opposite_state:
             double_clicked = True
             key_pressed = False
+            print(f"B")
+            return
 
         # 任务在进行中, 且不判定为`短击`, 就结束和完成任务
         elif double_clicked and not is_short_duration:
@@ -298,9 +347,15 @@ def click_mode(e: keyboard.KeyboardEvent):
                 Cosmic.online_translate_needed,
                 Config.hold_mode,
             )
+
             # if Config.enable_double_click_opposite_state:
             double_clicked = False
             key_pressed = False
+
+            # 恢復音频的播放
+            print(f"C1")
+            restore_audio_playing()
+            print(f"C2")
             return
 
         # 任务在进行中, 且为`短击`, 判定爲需要輸出 `簡/繁`, 并且结束函数
@@ -316,8 +371,15 @@ def click_mode(e: keyboard.KeyboardEvent):
                 Cosmic.online_translate_needed,
                 Config.hold_mode,
             )
+
             Cosmic.opposite_state = not Cosmic.opposite_state
             key_pressed = False
+
+            # 恢復音频的播放
+            print(f"D1")
+            # 這裏的函數 "restore_audio_playing()" 不應該加進來，不需要。 
+            # restore_audio_playing()
+            print(f"D2")
             # return
 
         # print(f'世界的尽头!')
@@ -325,7 +387,7 @@ def click_mode(e: keyboard.KeyboardEvent):
 
 # ======================长按模式==================================
 
-
+'''
 def hold_mode(e: keyboard.KeyboardEvent):
     """像对讲机一样，按下录音，松开停止"""
     global \
@@ -333,7 +395,7 @@ def hold_mode(e: keyboard.KeyboardEvent):
         double_clicked, \
         last_time_released, \
         hold_mode_first_time_cancel_task, \
-        unpause_needed
+        restore_audio_playing_needed 
 
     # 計算是否屬於短時間內按下`錄音鍵`
     is_short_duration = (
@@ -343,10 +405,10 @@ def hold_mode(e: keyboard.KeyboardEvent):
     # 短時間內,按下第二次錄音鍵判定爲需要輸出 `簡/繁`
     if is_short_duration and Config.enable_double_click_opposite_state:
         double_clicked = True
-        if Config.pause_other_audio and not unpause_needed:
+        if Config.pause_other_audio and not restore_audio_playing_needed :
             if process_name := audio_playering_app_name():
                 if process_name != "ffplay.exe":
-                    unpause_needed = True
+                    restore_audio_playing_needed  = True
 
     if e.event_type == "down" and not Cosmic.on:
         # 根據上一次是否短時間內(`is_short_duration`)按下錄音鍵,來判斷是否需要輸出 `簡/繁`
@@ -391,7 +453,189 @@ def hold_mode(e: keyboard.KeyboardEvent):
             Cosmic.online_translate_needed,
             Config.hold_mode,
         )
+'''
+'''
+def hold_mode(e: keyboard.KeyboardEvent):
+    """像对讲机一样，按下录音，松开停止"""
+    global task, double_clicked, last_time_released, key_pressed, last_time_pressed, is_short_duration
+    global hold_mode_first_time_cancel_task, restore_audio_playing_needed 
 
+    # 处理按键按下事件
+    if e.event_type == keyboard.KEY_DOWN:
+        # 仅在未按下状态时处理按下事件，防止重复触发
+        if not key_pressed:
+            key_pressed = True  # 标记为已按下
+            last_time_pressed = time.time()  # 统一获取当前时间，避免多次调用
+            # 计算是否属于短时间内按下录音键
+            is_short_duration = (last_time_pressed - last_time_released) < Config.threshold
+
+            # 处理双击逻辑
+            if is_short_duration and Config.enable_double_click_opposite_state:
+                double_clicked = True
+                _handle_audio_pause()
+
+            _handle_key_down(double_clicked, is_short_duration)
+    
+    # 处理按键松开事件（单独判断，不被key_pressed状态阻塞）
+    elif e.event_type == keyboard.KEY_UP:
+        # 仅在已按下状态时处理松开事件
+        if key_pressed:
+            last_time_released = time.time()  # 统一获取当前时间，避免多次调用
+            # is_short_duration = (last_time_pressed - last_time_released) < Config.threshold
+            _handle_key_up(last_time_pressed, is_short_duration)
+            key_pressed = False  # 标记为未按下
+
+
+def _handle_audio_pause():
+    global restore_audio_playing_needed 
+    """处理音频暂停相关逻辑"""
+    if Config.pause_other_audio and not restore_audio_playing_needed :
+        process_name = audio_playering_app_name()
+        if process_name and process_name != "ffplay.exe":
+            restore_audio_playing_needed  = True
+
+
+def _handle_key_down(double_clicked, is_short_duration):
+    """处理按键按下时的逻辑"""
+    # 处理双击切换简/繁状态
+    if double_clicked and Config.enable_double_click_opposite_state:
+        Cosmic.opposite_state = not Cosmic.opposite_state
+    
+    translate_needed()
+    send_signal_to_hint_while_recording(
+        True,
+        is_short_duration,
+        Cosmic.offline_translate_needed,
+        Cosmic.online_translate_needed,
+        Config.hold_mode,
+    )
+    # 启动录音任务
+    launch_task()
+
+
+def _handle_key_up(last_time_pressed, is_short_duration):
+    """处理按键松开时的逻辑"""
+    global last_time_released, hold_mode_first_time_cancel_task, double_clicked
+    
+    # 更新最后松开时间
+    # last_time_released = last_time_pressed
+    # duration = last_time_released - last_time_pressed
+
+    # 处理任务取消或完成
+    if is_short_duration and not double_clicked:
+        hold_mode_first_time_cancel_task = True
+        cancel_task()
+    else:
+        finish_task()
+        # 恢复按键状态
+        if not double_clicked and Config.restore_key:
+            time.sleep(0.01)
+            keyboard.send(Config.speech_recognition_shortcut)
+        # 重置双击状态
+        if Config.enable_double_click_opposite_state:
+            double_clicked = False
+
+    # 发送录音结束信号
+    send_signal_to_hint_while_recording(
+        False,
+        is_short_duration,
+        Cosmic.offline_translate_needed,
+        Cosmic.online_translate_needed,
+        Config.hold_mode,
+    )
+'''
+
+def hold_mode(e: keyboard.KeyboardEvent):
+    """像对讲机一样，按下录音，松开停止"""
+    # 改進: 20250918: 增加了 key_pressed 变量用于追踪按键是否已经被按下， 以免某些函数会被重复触发。
+    # 改進: 20250918: 在此函数中, 取消了 Cosmic.on 的运用, 改为了 last_time_released & last_time_pressed 变量来进行时间的记录和计算.
+
+    # Bug1: 20250918: 在Hold Mode下, 1. 如果按下和弹起`錄音鍵` 单次的時間小于< Config.threshold 以及 2.双击的功能, 会导致播放中的浏览器或者音乐播放器 *不会恢复播放* 的状态。
+    #   解決方法-Bug1 20250919: 2.双击的功能: 不会回复播放的原因是因为第一次弹起來的時候, 恢復播放的时候会有一段空档期, 这段期间使用电平侦测-是否有应用在播放的方法就会失效。 解決方法是增加了 saved_result_for_restore_audio_playing_needed 变量来保存第一次的状态。 
+    #   解決方法-Bug1 20250919: 1.小于< Config.threshold: 单次按下和弹起录音键 ， 就会快速的停止和恢复播放。但是这两个指令间隔的时间太短，导致恢复的命令被吞掉了，所以把恢复的命令放到最后，让他有更多的时间执行。 同时`def cancel_task()` 和 `def finish_task()` 里面的恢复播放命令被取消了，放到独立的函數里执行。 
+
+    # Bug2: 20250918: 在上述的改动后 ，需要继续观察是否还会存在"任务顺序错乱"的情况。
+    # Bug3: 20250918: holdmode = true: shift + 录音键(双击) 失效了, 变成了输出简体中文 。 holdmode = false: 正常。
+    # 更新 20250919: 需要更新最新版本的 "sherpa-onnx-sense-voice-zh-en-ja-ko-yue-int8-2025-09-09"
+
+    # Bug5: 20250919: hold_mode: 录音键(双击) 有機會導致不會恢復播放(原本已在播放)
+    #    解決方法-Bug5: def launch_task(): "# 录音时暂停其他音频播放 且 有音频正在播放" 放回到中間之後, 只測試出一次沒有恢復播放的情況。 需要繼續觀察.. 
+    global \
+        task, \
+        key_pressed, \
+        double_clicked, \
+        last_time_pressed, \
+        last_time_released, \
+        hold_mode_first_time_cancel_task, \
+        is_short_duration, \
+        restore_audio_playing_needed, \
+        saved_result_for_restore_audio_playing_needed
+    
+    # 处理按键按下事件
+    if e.event_type == "down":
+        if not key_pressed:
+            key_pressed = True  # 标记为已按下
+            print(f"1. restore_audio_playing_needed:{restore_audio_playing_needed}")
+            last_time_pressed = time.time()
+            # 計算是否屬於短時間內按下`錄音鍵`
+            is_short_duration = (last_time_pressed - last_time_released) < Config.threshold
+
+
+            # 短時間內,按下第二次錄音鍵判定爲需要輸出 `簡/繁`
+            if is_short_duration and Config.enable_double_click_opposite_state:
+                double_clicked = True
+
+            # 处理双击切换简/繁状态
+            if double_clicked and Config.enable_double_click_opposite_state:
+                Cosmic.opposite_state = not Cosmic.opposite_state
+
+            translate_needed()
+            send_signal_to_hint_while_recording(
+                True,
+                is_short_duration,
+                Cosmic.offline_translate_needed,
+                Cosmic.online_translate_needed,
+                Config.hold_mode,
+            )
+            # 启动录音任务
+            launch_task()
+
+    elif e.event_type == "up":
+        # 仅在已按下状态时处理松开事件
+        if key_pressed:
+            # 标记最后弹起的时间
+            last_time_released = time.time()
+            # 计算按键弹起来和按下的间隔
+            duration = last_time_released - last_time_pressed
+            # 取消或完成任务
+            if duration < Config.threshold and not double_clicked:
+                hold_mode_first_time_cancel_task = True
+                cancel_task()
+
+            else:
+                finish_task()
+                # 任务完成后, 还原释放案件的时间, 以免两个任务的时间间隔太短导致误判
+                last_time_released = 0
+                # 松开快捷键后，再按一次，恢复 CapsLock 或 Shift 等按键的状态
+                if not double_clicked and Config.restore_key:
+                    # time.sleep(0.01)
+                    keyboard.send(Config.speech_recognition_shortcut)
+                # 恢复輸出 `簡/繁` 原来的狀態
+                if Config.enable_double_click_opposite_state:
+                    double_clicked = False
+
+            # 20250918: 这里不应该向 AHK 发送 is_short_duration=True 的信号, 否则会导致"语音输入中"的提示不会进行取消 (跟AHK代码逻辑有关)， 最后，不影响AHK的提示。 
+            send_signal_to_hint_while_recording(
+                False,
+                False,
+                Cosmic.offline_translate_needed,
+                Cosmic.online_translate_needed,
+                Config.hold_mode,
+            )
+            # 恢復音频的播放
+            restore_audio_playing()
+            key_pressed = False  # 标记为未按下
+            print(f"Last. restore_audio_playing_needed:{restore_audio_playing_needed}")
 
 # ==================== 绑定 handler ===============================
 

--- a/util/client_shortcut_handler.py
+++ b/util/client_shortcut_handler.py
@@ -34,6 +34,7 @@ key_pressed = False
 saved_result_for_offline_translate_needed = False
 saved_result_for_online_translate_needed = False
 unmute_task = None
+restore_capslock_task = None
 sessions = []
 
 
@@ -132,6 +133,7 @@ def launch_task():
             # 1. 如果我把按鍵抬起的時間放在10秒後: 功能正常, ✔會恢復播放
             # 2. 如果我把按鍵抬起的時間放在10秒內: 功能正常, ✘不會恢復播放
                 # 現在不採用異步的方法, 除非有辦法能解決短時間內抬起，不會恢復播放的問題
+            # Git: 753321e008117e227d666efba188543c4200b48e
 
     # 开始任务时播放提示音
     import shutil
@@ -218,120 +220,6 @@ def launch_task():
         restore_audio_playing_needed = False
 
 
-"""
-# 這個函數採用了 异步async def delay_pause()
-def launch_task():
-    # - [x] 改進點: 20250925: time.sleep(0.6)這句代碼會阻塞整個主线程, 導致雙擊功能會有一點點的錄音延遲，不爽。
-        # ✔思路1: 把整組 pause_other_audio 相關的代碼放到 task = asyncio.run_coroutine_threadsafe(send_audio(),Cosmic.loop,) 的後面, 從而避免影響接收聲音。 為方便測試調整為10秒"time.sleep(10.6)", 測試結果: 是可行的。
-            # 1. 如果我把按鍵抬起的時間放在10秒後: 功能正常, ✔會恢復播放
-            # 2. 如果我把按鍵抬起的時間放在10秒內: 功能正常, ✔會恢復播放, 但是有一點副作用就是必須"10秒"後才會恢復運行後面的代碼
-                # 這個副作用是可以接受，因此現在採用此辦法
-                # - Bug: 在應用程式全部暫停播放的情況下使用錄音會導致播放的情況
-                    # - 只在hold_mode的情況出現, 是這個 "and not Config.hold_mode" 的判斷問題
-
-        # 思路2: 採用异步async def delay_pause(), 為方便測試調整為10秒"asyncio.sleep(10.5)", 測試結果:
-            # 1. 如果我把按鍵抬起的時間放在10秒後: 功能正常, ✔會恢復播放
-            # 2. 如果我把按鍵抬起的時間放在10秒內: 功能正常, ✘不會恢復播放
-                # 現在不採用異步的方法, 除非有辦法能解決短時間內抬起，不會恢復播放的問題
-
-        
-    # 开始任务时播放提示音
-    import shutil
-
-    if shutil.which("ffplay") and Config.play_start_music:
-        from util.client_play_music import play_music
-
-        play_music(Config.start_music_path, Config.start_music_volume)
-
-    global hold_mode_first_time_cancel_task
-    # 确认是否需要翻译
-    # 改为独立调用
-    # translate_needed()
-
-    if (
-        not double_clicked
-        and Config.only_enable_microphones_when_pressed_record_shortcut
-    ):
-        # 重启音频流; 在双击情况下, 只在第一次的时候启动(单击模式)
-        stream_reopen()
-        Cosmic.stream.start()
-
-    # 长按模式(hold_mode)双击功能 第二次重启不适用于上面的判断, 因此，需要下面来判断是否重启音频流
-    # 长按模式(hold_mode)双击功能 確實需要第二次啓動音频流, 设计的时候就是如此, 因为会进行一次 start  cancel 的流程, 然后第二次啓動才是双击功能的录音
-    elif (
-        hold_mode_first_time_cancel_task
-        and double_clicked
-        and Config.only_enable_microphones_when_pressed_record_shortcut
-    ):
-        stream_reopen()
-        Cosmic.stream.start()
-        hold_mode_first_time_cancel_task = False
-    # 记录开始时间
-    t1 = time.time()
-
-    # 将开始标志放入队列
-    asyncio.run_coroutine_threadsafe(
-        Cosmic.queue_in.put({"type": "begin", "time": t1, "data": None}), Cosmic.loop
-    )
-
-    # 录音时静音其他音频播放
-    if Config.mute_other_audio:
-        mute_all_sessions()
-
-    # 录音时暂停其他音频播放 且 有音频正在播放
-    global restore_audio_playing_needed, saved_result_for_restore_audio_playing_needed, process_name
-    if Config.pause_other_audio and not restore_audio_playing_needed:
-
-        # 针对双击导致停止和播放的指令过快的问题，增加了时间延迟
-        if is_short_duration:
-            # 用异步任务执行延迟，不阻塞当前线程
-            async def delay_pause():
-                global restore_audio_playing_needed, saved_result_for_restore_audio_playing_needed, process_name
-
-                await asyncio.sleep(0.6)  # 异步延迟，不影响录音
-
-                if process_name := audio_playering_app_name():
-                    if process_name != "ffplay.exe":
-                        keyboard.send("play/pause")
-                        restore_audio_playing_needed = True
-
-                if process_name is None:
-                    # 恢復原狀：修復因 "saved_result_for_restore_audio_playing_needed" 變量導致播放器誤播的狀況(在已經本身停播的情況下)。
-                    saved_result_for_restore_audio_playing_needed = False
-                    restore_audio_playing_needed = False
-
-            # 启动异步任务，放入事件循环
-            asyncio.run_coroutine_threadsafe(delay_pause(), Cosmic.loop)
-
-        # 适用于非双击的情况
-        if not is_short_duration:
-            if process_name := audio_playering_app_name():
-                if process_name != "ffplay.exe" :
-                    keyboard.send("play/pause")
-                    restore_audio_playing_needed  = True
-
-            saved_result_for_restore_audio_playing_needed = restore_audio_playing_needed
-
-            # 恢復原狀：修復因 "saved_result_for_restore_audio_playing_needed" 變量導致播放器誤播的狀況(在已經本身停播的情況下)。
-            if process_name is None and not Config.hold_mode:
-                saved_result_for_restore_audio_playing_needed = False
-                restore_audio_playing_needed = False
-
-
-    # 通知录音线程可以向队列放数据了
-    Cosmic.on = t1
-
-    # 打印动画：正在录音
-    status.start()
-
-    # 启动识别任务
-    global task
-    task = asyncio.run_coroutine_threadsafe(
-        send_audio(),
-        Cosmic.loop,
-    )
-"""
-
 def cancel_task():
     # 通知停止录音，关掉滚动条
     Cosmic.on = False
@@ -378,6 +266,16 @@ def finish_task():
 
 
 # =================单击模式======================
+# 封装需要异步执行的原版 CapsLock 功能（延迟+恢复）
+async def original_capslock_function():
+    global restore_capslock_task
+    if Config.restore_key:
+        # 开始"倒数"至少0.3秒(threshold)
+        await asyncio.sleep(Config.threshold)
+        # "倒数"0.3秒后，如果该按键依然是被按下的状态，就执行原本功能
+        if keyboard.is_pressed(Config.speech_recognition_shortcut):
+            keyboard.send(Config.speech_recognition_shortcut)
+        restore_capslock_task = None
 
 
 def click_mode(e: keyboard.KeyboardEvent):
@@ -388,8 +286,8 @@ def click_mode(e: keyboard.KeyboardEvent):
     # 2.1. 原来的设计: 使用`CapsLock`开启大小写的功能, 在单击模式下`未触发`录音模式之前,长按这个按键切换有机率失败，但是进行录音模式`之后`, 成功的几率极大.
     # 2.2. 这是因为: `def manage_task(e: Event): `它是按下按键就立刻开启任务，在开启任务之后才进行判断是否`长/短`按。这就是导致有几率失败的原因
 
-    # 3. `長按` = 进行大小写切换的功能, 需要按键抬起后才能切换;
-    # 3.1. 如果需要按下之后是根据按下(不需要抬起)的时间自动进行大小写切换的功能, 可以参考原来作者的代码`def count_down(e: Event):`
+    # 3.改進點: `長按` = 进行大小写切换的功能, 需要按键抬起后才能切换;
+        # - [x] 改進: 20250926: 通过异步的方法实现了原版的长按功能(至少按下0.3秒,click_mode only), 在`长按`的过程中, 按键会自动重复, 就像原来的"caps lock"自己亮起的一样。 
 
     # 4. 为了解决在 Windows 下按键会自动重复的问题 : key_pressed 变量用于追踪按键是否已经被按下并记录时间。当按键第一次被按下时，记录时间并将 key_pressed 设为 True，防止重复记录时间。当按键释放时，将 key_pressed 重新设为 False，允许下一次按键记录新的时间。
     
@@ -410,35 +308,40 @@ def click_mode(e: keyboard.KeyboardEvent):
         key_pressed, \
         double_clicked, \
         is_short_duration, \
-        restore_audio_playing_needed 
+        restore_audio_playing_needed, \
+        restore_capslock_task
 
     if e.event_type == keyboard.KEY_DOWN and not key_pressed:
+        key_pressed = True
+
+        if restore_capslock_task is None:
+            restore_capslock_task = asyncio.run_coroutine_threadsafe(
+            original_capslock_function(),  # 提交封装好的异步任务
+            Cosmic.loop  # 目标事件循环
+            )
+
         # 計算是否屬於短時間內雙击`錄音鍵`
         is_short_duration = (
             True if time.time() - last_time_released < Config.threshold else False
         )
-
         last_time_pressed = time.time()
-        key_pressed = True
 
     elif e.event_type == keyboard.KEY_UP:
         last_time_released = time.time()
 
-        # 记录是否有任务; 此处已改用变量:`double_clicked` 来判断任务是否进行中
-        # on = Cosmic.on
+        # 取消 延迟恢复原版CapsLock功能的任务
+        if restore_capslock_task is not None:
+            restore_capslock_task_cancelled = restore_capslock_task.cancel()
+            # if restore_capslock_task_cancelled:
+            #     print("成功取消延迟的restore_capslock_task操作")
+            # else:
+            #     print("取消失败（任务可能已执行或已完成）")
+            restore_capslock_task = None
 
         # 如果大于`Config.threshold`的值, 判定为`長按`, 就取消本栈启动的任务(`cancel_task()`)
-        if last_time_released - last_time_pressed >= Config.threshold:
-            # 函数`cancel_task()` : 他和我想象中的功能可能不一样
-            # 我想象中的功能: `長按` = 进行大小写切换
-            # 原来的功能: 可能是 中断并且不输出 已经录入的语音文字
-            # 如果启动以下的函数`cancel_task()` : Bug 复现方法是 按一次`录音键`进入录音状态, 随后进行一次长按, 就会进入错乱状态.
-            # 如果没有特殊的需求, 现在的状况可以满足 `長按` = 进行大小写切换 的功能
-            # 否则需要进入函数`cancel_task()` 修改
-            # cancel_task()
-
+        if last_time_released - last_time_pressed >= Config.threshold and Config.restore_key:
             # 判定为`長按`，发送原來的按键功能
-            keyboard.send(Config.speech_recognition_shortcut)
+            # keyboard.send(Config.speech_recognition_shortcut)
             key_pressed = False
             return
 
@@ -553,7 +456,7 @@ def hold_mode(e: keyboard.KeyboardEvent):
             if is_short_duration:
                 double_clicked = True
 
-            # 处理双击切换简/繁状态
+            # 处理双击切换简/繁状态, 当初为何使用这个double_clicked变量来判断？嗯，记不起来了. 可能是当时还没使用key_pressed来锁定
             if double_clicked:
                 Cosmic.opposite_state = not Cosmic.opposite_state
 

--- a/util/client_shortcut_handler.py
+++ b/util/client_shortcut_handler.py
@@ -277,9 +277,11 @@ def click_mode(e: keyboard.KeyboardEvent):
 
     # 4. 为了解决在 Windows 下按键会自动重复的问题 : key_pressed 变量用于追踪按键是否已经被按下并记录时间。当按键第一次被按下时，记录时间并将 key_pressed 设为 True，防止重复记录时间。当按键释放时，将 key_pressed 重新设为 False，允许下一次按键记录新的时间。
     
-    # 20250918: click_mode : "double_clicked" 变量 在此处函数中 改为常駐, 他会导致 Config.enable_double_click_opposite_state 这个配置项失效， 需要修正
-    # Bug4: 20250919: click_mode : "Shift + double_clicked or double_clicked" 有機會導致恢復音頻播放失敗.. 原因不明，需要再跟进。 觀察: 先是停下播放之後，然後輸出文字後聽到一些聲音，但是很快就又停止了。 
-    # 解决方法-Bug4: 函数: "elif (double_clicked and is_short_duration)" : 這裏的函數 "restore_audio_playing()" 不應該加進來，不需要。 
+    # -[x] 20250918: click_mode : "double_clicked" 变量 在此处函数中 改为常駐, 他会导致 Config.enable_double_click_opposite_state 这个配置项失效， 需要修正
+            # 解决方法: client_recv_result.py : 把判断变量的位置改放在 async def recv_result() 后面。 同时把 client_shortcut_handler.py 里面的所有Config.enable_double_click_opposite_state 取消掉 。 
+
+    # -[x] Bug4: 20250919: click_mode : "Shift + double_clicked or double_clicked" 有機會導致恢復音頻播放失敗.. 原因不明，需要再跟进。 觀察: 先是停下播放之後，然後輸出文字後聽到一些聲音，但是很快就又停止了。 
+            # 解决方法-Bug4: 函数: "elif (double_clicked and is_short_duration)" : 這裏的函數 "restore_audio_playing()" 不應該加進來，不需要。 
     global \
         last_time_pressed, \
         last_time_released, \
@@ -547,19 +549,22 @@ def _handle_key_up(last_time_pressed, is_short_duration):
 
 def hold_mode(e: keyboard.KeyboardEvent):
     """像对讲机一样，按下录音，松开停止"""
-    # 改進: 20250918: 增加了 key_pressed 变量用于追踪按键是否已经被按下， 以免某些函数会被重复触发。
-    # 改進: 20250918: 在此函数中, 取消了 Cosmic.on 的运用, 改为了 last_time_released & last_time_pressed 变量来进行时间的记录和计算.
+    # -[x] 改進: 20250918: 增加了 key_pressed 变量用于追踪按键是否已经被按下， 以免某些函数会被重复触发。
+    # -[x] 改進: 20250918: 在此函数中, 取消了 Cosmic.on 的运用, 改为了 last_time_released & last_time_pressed 变量来进行时间的记录和计算.
 
-    # Bug1: 20250918: 在Hold Mode下, 1. 如果按下和弹起`錄音鍵` 单次的時間小于< Config.threshold 以及 2.双击的功能, 会导致播放中的浏览器或者音乐播放器 *不会恢复播放* 的状态。
-    #   解決方法-Bug1 20250919: 2.双击的功能: 不会回复播放的原因是因为第一次弹起來的時候, 恢復播放的时候会有一段空档期, 这段期间使用电平侦测-是否有应用在播放的方法就会失效。 解決方法是增加了 saved_result_for_restore_audio_playing_needed 变量来保存第一次的状态。 
-    #   解決方法-Bug1 20250919: 1.小于< Config.threshold: 单次按下和弹起录音键 ， 就会快速的停止和恢复播放。但是这两个指令间隔的时间太短，导致恢复的命令被吞掉了，所以把恢复的命令放到最后，让他有更多的时间执行。 同时`def cancel_task()` 和 `def finish_task()` 里面的恢复播放命令被取消了，放到独立的函數里执行。 
+    # -[x] Bug1: 20250918: 在Hold Mode下, 1. 如果按下和弹起`錄音鍵` 单次的時間小于< Config.threshold 以及 2.双击的功能, 会导致播放中的浏览器或者音乐播放器 *不会恢复播放* 的状态。
+        # -[x]  解決方法-Bug1 20250919: 2.双击的功能: 不会回复播放的原因是因为第一次弹起來的時候, 恢復播放的时候会有一段空档期, 这段期间使用电平侦测-是否有应用在播放的方法就会失效。 解決方法是增加了 saved_result_for_restore_audio_playing_needed 变量来保存第一次的状态。 
+        # -[x]  解決方法-Bug1 20250919: 1.小于< Config.threshold: 单次按下和弹起录音键 ， 就会快速的停止和恢复播放。但是这两个指令间隔的时间太短，导致恢复的命令被吞掉了，所以把恢复的命令放到最后，让他有更多的时间执行。 同时`def cancel_task()` 和 `def finish_task()` 里面的恢复播放命令被取消了，放到独立的函數里执行。 
 
-    # Bug2: 20250918: 在上述的改动后 ，需要继续观察是否还会存在"任务顺序错乱"的情况。
-    # Bug3: 20250918: holdmode = true: shift + 录音键(双击) 失效了, 变成了输出简体中文 。 holdmode = false: 正常。
-    # 更新 20250919: 需要更新最新版本的 "sherpa-onnx-sense-voice-zh-en-ja-ko-yue-int8-2025-09-09"
+    # -[!] Bug2: 20250918: 在上述的改动后 ，需要继续观察是否还会存在"任务顺序错乱"的情况。
+    # -[ ] Bug3: 20250918: holdmode = true: shift + 录音键(双击) 失效了, 变成了输出简体中文 。 holdmode = false: 正常。
+        # 解決方法-Bug3: 20250919: Config.enable_double_click_opposite_state= false: 修改成这个之后，他居然可以使用 "shift +双击" = 英文输出了
+        # 解決方法-Bug3: 20250919: 把 hold_mode() 里面的 Config.enable_double_click_opposite_state 删除掉, "shift +双击" = 中文输出， 看来BUG和这个 enable_double_click_opposite_state 有关， 需要继续解决。 (click_mode 没有这个问题)
 
-    # Bug5: 20250919: hold_mode: 录音键(双击) 有機會導致不會恢復播放(原本已在播放)
-    #    解決方法-Bug5: def launch_task(): "# 录音时暂停其他音频播放 且 有音频正在播放" 放回到中間之後, 只測試出一次沒有恢復播放的情況。 需要繼續觀察.. 
+    # -[ ] 更新 20250919: 需要更新最新版本的 "sherpa-onnx-sense-voice-zh-en-ja-ko-yue-int8-2025-09-09"
+
+    # -[!] Bug5: 20250919: hold_mode: 录音键(双击) 有機會導致不會恢復播放(原本已在播放)
+        # 解決方法-Bug5: def launch_task(): "# 录音时暂停其他音频播放 且 有音频正在播放" 放回到中間之後, 只測試出一次沒有恢復播放的情況。 需要繼續觀察.. 
     global \
         task, \
         key_pressed, \
@@ -582,11 +587,13 @@ def hold_mode(e: keyboard.KeyboardEvent):
 
 
             # 短時間內,按下第二次錄音鍵判定爲需要輸出 `簡/繁`
-            if is_short_duration and Config.enable_double_click_opposite_state:
+            if is_short_duration:
+            # and Config.enable_double_click_opposite_state:
                 double_clicked = True
 
             # 处理双击切换简/繁状态
-            if double_clicked and Config.enable_double_click_opposite_state:
+            if double_clicked:
+            # and Config.enable_double_click_opposite_state:
                 Cosmic.opposite_state = not Cosmic.opposite_state
 
             translate_needed()
@@ -621,8 +628,8 @@ def hold_mode(e: keyboard.KeyboardEvent):
                     # time.sleep(0.01)
                     keyboard.send(Config.speech_recognition_shortcut)
                 # 恢复輸出 `簡/繁` 原来的狀態
-                if Config.enable_double_click_opposite_state:
-                    double_clicked = False
+                #if Config.enable_double_click_opposite_state:
+                double_clicked = False
 
             # 20250918: 这里不应该向 AHK 发送 is_short_duration=True 的信号, 否则会导致"语音输入中"的提示不会进行取消 (跟AHK代码逻辑有关)， 最后，不影响AHK的提示。 
             send_signal_to_hint_while_recording(

--- a/util/client_shortcut_handler.py
+++ b/util/client_shortcut_handler.py
@@ -147,11 +147,17 @@ def launch_task():
 
     # 录音时暂停其他音频播放 且 有音频正在播放
     global restore_audio_playing_needed, saved_result_for_restore_audio_playing_needed
-    if Config.pause_other_audio and not restore_audio_playing_needed :
+    if Config.pause_other_audio and not restore_audio_playing_needed:
+        # 针对双击导致停止和播放的指令过快的问题，增加了时间延迟
+        if is_short_duration:
+                # 试过的时间: 0.2✘; 0.3✘; 0.4✔; 0.5✔;1✔
+                time.sleep(0.4)
+                
+        print(f"is_short_duration: {is_short_duration}")
         if process_name := audio_playering_app_name():
             print(f"launch  1. Audio is currently playering by {process_name} .")
             print(f"launch  1. restore_audio_playing_needed:{restore_audio_playing_needed}")
-            if process_name != "ffplay.exe" :
+            if process_name != "ffplay.exe":
                 keyboard.send("play/pause")
                 # if process_name != None:
                 restore_audio_playing_needed  = True
@@ -279,11 +285,18 @@ def click_mode(e: keyboard.KeyboardEvent):
 
     # 4. 为了解决在 Windows 下按键会自动重复的问题 : key_pressed 变量用于追踪按键是否已经被按下并记录时间。当按键第一次被按下时，记录时间并将 key_pressed 设为 True，防止重复记录时间。当按键释放时，将 key_pressed 重新设为 False，允许下一次按键记录新的时间。
     
-    # - [x] 20250918: click_mode : "double_clicked" 变量 在此处函数中 改为常駐, 他会导致 Config.enable_double_click_opposite_state 这个配置项失效， 需要修正
+    # - [x] Bug6: 20250918: click_mode : "double_clicked" 变量 在此处函数中 改为常駐, 他会导致 Config.enable_double_click_opposite_state 这个配置项失效， 需要修正
             # 解决方法: client_recv_result.py : 把判断变量的位置改放在 async def recv_result() 后面。 同时把 client_shortcut_handler.py 里面的所有Config.enable_double_click_opposite_state 取消掉 。 
 
     # - [x] Bug4: 20250919: click_mode : "Shift + double_clicked or double_clicked" 有機會導致恢復音頻播放失敗.. 原因不明，需要再跟进。 觀察: 先是停下播放之後，然後輸出文字後聽到一些聲音，但是很快就又停止了。 
             # 解决方法-Bug4: 函数: "elif (double_clicked and is_short_duration)" : 這裏的函數 "restore_audio_playing()" 不應該加進來，不需要。 
+
+    # - [ ] 潜在的改善点: 20250924: 假如有两个应用在运行, 其中第1个在播放，第2个在暂停, 那么我进行录音，第一个会被暂停，而第2个在录音期间依然会被播放(靜音), 这不符合最初暂停所有的应用的设想. 
+        # 解决思路是根据每一个应用侦测它的播放状态, 最终根据此状态依次针对每一个应用进行判断是否恢复播放.但是需要解决的是:
+            # 1. 是否能指定某一个应用进行暂停或者播放？
+            # 2. 如何判断某一个应用是否正在播放？audio_playering_app_name() 给出的资讯需要放入数组中.
+        
+
     global \
         last_time_pressed, \
         last_time_released, \
@@ -569,7 +582,10 @@ def hold_mode(e: keyboard.KeyboardEvent):
         # 解決方法-更新: 20250924: 更新成功了, 但是沒發現這個新模型有標點功能，因此需要加載額外的標點功能模型 。 最終的感覺不如舊的模型好，因此還原 。 
 
     # - [?] Bug5: 20250919: hold_mode: 录音键(双击) 有機會導致不會恢復播放(原本已在播放)
-        # 解決方法-Bug5: def launch_task(): "# 录音时暂停其他音频播放 且 有音频正在播放" 放回到中間之後, 只測試出一次沒有恢復播放的情況。 需要繼續觀察.. 
+        # 观察-Bug5: def launch_task(): "# 录音时暂停其他音频播放 且 有音频正在播放" 放回到中間之後, 只測試出一次沒有恢復播放的情況。 需要繼續觀察.. 
+        # 观察-Bug5: 20250924: 第一次按下会暂停播放，抬起就会恢复播放, 然后短时间内第二次按下会静音，这里本应是需要暂停的, 但是会继续播放(这里不符合预想的结果,推测是因为有三次的快速操作,导致第三次的动作被吞掉了), 跟着第二次抬起(已经过了一段时间),就会被错误的暂停了(restore_audio_playing_needed = true)。 
+        # 解决方法-Bug5: 20250924: 在这里 def launch_task() 加上一个, 但凡是快速按下第二次(is_short_duration)就会延迟一段时间. 逻辑上以及实际测试只有 hold_mode 会应用这个延迟。 
+        
     global \
         task, \
         key_pressed, \
@@ -642,7 +658,7 @@ def hold_mode(e: keyboard.KeyboardEvent):
                 finish_task()
                 print(f"O3. offline_translate_needed:{Cosmic.offline_translate_needed}")
                 # 任务完成后, 还原释放案件的时间, 以免两个任务的时间间隔太短导致误判
-                last_time_released = 0
+                # last_time_released = 0
                 # 松开快捷键后，再按一次，恢复 CapsLock 或 Shift 等按键的状态
                 if not double_clicked and Config.restore_key:
                     # time.sleep(0.01)

--- a/util/client_shortcut_handler.py
+++ b/util/client_shortcut_handler.py
@@ -27,6 +27,7 @@ restore_audio_playing_needed  = False
 saved_result_for_restore_audio_playing_needed = False
 double_clicked = False
 is_short_duration = False
+is_short_press = False
 hold_mode_first_time_cancel_task = False
 last_time_pressed = 0
 last_time_released = 0
@@ -91,6 +92,9 @@ def restore_audio_playing():
     restore_audio_playing_needed = saved_result_for_restore_audio_playing_needed
 
     if Config.pause_other_audio and restore_audio_playing_needed:
+        # hold_mode: 切换字母大小: 还是出现了一次恢复播放失败的情况, 保险起见专门为此情况增加了延迟
+        if Config.hold_mode and is_short_press:
+            time.sleep(0.1)
         keyboard.send("play/pause")
         restore_audio_playing_needed  = False
 
@@ -444,6 +448,7 @@ def hold_mode(e: keyboard.KeyboardEvent):
         last_time_released, \
         hold_mode_first_time_cancel_task, \
         is_short_duration, \
+        is_short_press, \
         restore_audio_playing_needed, \
         saved_result_for_restore_audio_playing_needed, \
         saved_result_for_offline_translate_needed, \
@@ -489,9 +494,9 @@ def hold_mode(e: keyboard.KeyboardEvent):
             # 标记最后弹起的时间
             last_time_released = time.time()
             # 计算按键弹起来和按下的间隔
-            duration = last_time_released - last_time_pressed
+            is_short_press = (last_time_released - last_time_pressed) < Config.threshold
             # 取消或完成任务
-            if duration < Config.threshold and not double_clicked:
+            if is_short_press and not double_clicked:
                 hold_mode_first_time_cancel_task = True
                 cancel_task()
 
@@ -522,6 +527,7 @@ def hold_mode(e: keyboard.KeyboardEvent):
 
             # 恢復音频的播放
             restore_audio_playing()
+            is_short_press = False
             key_pressed = False  # 标记为未按下
 
 # ==================== 绑定 handler ===============================

--- a/util/client_shortcut_handler.py
+++ b/util/client_shortcut_handler.py
@@ -101,7 +101,111 @@ def translate_needed():
         Cosmic.online_translate_needed = False
 
 
+# 這個函數採用了: 把整組 pause_other_audio 相關的代碼放到 task = asyncio.run_coroutine_threadsafe(send_audio(),Cosmic.loop,) 的後面, 從而避免影響接收聲音。
 def launch_task():
+    # - [x] 改進點: 20250925: time.sleep(0.6)這句代碼會阻塞整個主线程, 導致雙擊功能會有一點點的錄音延遲，不爽。
+        # 思路1: 把整組 pause_other_audio 相關的代碼放到 task = asyncio.run_coroutine_threadsafe(send_audio(),Cosmic.loop,) 的後面, 從而避免影響接收聲音。 為方便測試調整為10秒"time.sleep(10.6)", 測試結果: 是可行的。
+            # 1. 如果我把按鍵抬起的時間放在10秒後: 功能正常, ✔會恢復播放
+            # 2. 如果我把按鍵抬起的時間放在10秒內: 功能正常, ✔不會恢復播放, 但是有一點副作用就是必須"10秒"後才會恢復運行後面的代碼
+                # 這個副作用是可以接受，因此現在採用此辦法
+
+        # 思路2: 採用异步async def delay_pause(), 為方便測試調整為10秒"asyncio.sleep(10.5)", 測試結果:
+            # 1. 如果我把按鍵抬起的時間放在10秒後: 功能正常, ✔會恢復播放
+            # 2. 如果我把按鍵抬起的時間放在10秒內: 功能正常, ✘不會恢復播放
+                # 現在不採用異步的方法, 除非有辦法能解決短時間內抬起，不會恢復播放的問題
+
+    # 开始任务时播放提示音
+    import shutil
+    if shutil.which("ffplay") and Config.play_start_music:
+        from util.client_play_music import play_music
+
+        play_music(Config.start_music_path, Config.start_music_volume)
+
+    global hold_mode_first_time_cancel_task
+    # 确认是否需要翻译
+    # 改为独立调用
+    # translate_needed()
+
+    if (
+        not double_clicked
+        and Config.only_enable_microphones_when_pressed_record_shortcut
+    ):
+        # 重启音频流; 在双击情况下, 只在第一次的时候启动(单击模式)
+        stream_reopen()
+        Cosmic.stream.start()
+
+    # 长按模式(hold_mode)双击功能 第二次重启不适用于上面的判断, 因此，需要下面来判断是否重启音频流
+    # 长按模式(hold_mode)双击功能 確實需要第二次啓動音频流, 设计的时候就是如此, 因为会进行一次 start  cancel 的流程, 然后第二次啓動才是双击功能的录音
+    elif (
+        hold_mode_first_time_cancel_task
+        and double_clicked
+        and Config.only_enable_microphones_when_pressed_record_shortcut
+    ):
+        stream_reopen()
+        Cosmic.stream.start()
+        hold_mode_first_time_cancel_task = False
+    # 记录开始时间
+    t1 = time.time()
+
+    # 将开始标志放入队列
+    asyncio.run_coroutine_threadsafe(
+        Cosmic.queue_in.put({"type": "begin", "time": t1, "data": None}), Cosmic.loop
+    )
+
+    # 录音时静音其他音频播放
+    if Config.mute_other_audio:
+        mute_all_sessions()
+
+    # 通知录音线程可以向队列放数据了
+    Cosmic.on = t1
+
+    # 打印动画：正在录音
+    status.start()
+
+    # 启动识别任务
+    global task
+    task = asyncio.run_coroutine_threadsafe(
+        send_audio(),
+        Cosmic.loop,
+    )
+
+    # 录音时暂停其他音频播放 且 有音频正在播放
+    global restore_audio_playing_needed, saved_result_for_restore_audio_playing_needed
+    if Config.pause_other_audio and not restore_audio_playing_needed:
+        # 针对双击导致停止和播放的指令过快的问题，增加了时间延迟
+        if is_short_duration:
+                # 试过的时间: 0.2✘; 0.3✘; 0.4✘; 0.5✔;1✔
+                time.sleep(0.6)
+                
+        if process_name := audio_playering_app_name():
+            if process_name != "ffplay.exe" :
+                keyboard.send("play/pause")
+                restore_audio_playing_needed  = True
+
+            if not is_short_duration:
+                saved_result_for_restore_audio_playing_needed = restore_audio_playing_needed
+
+    # 恢復原狀：修復因 "saved_result_for_restore_audio_playing_needed" 變量導致播放器誤播的狀況(在已經本身停播的情況下)。
+    if process_name is None:
+        saved_result_for_restore_audio_playing_needed = False
+        restore_audio_playing_needed = False
+
+
+"""
+# 這個函數採用了 异步async def delay_pause()
+def launch_task():
+    # - [x] 改進點: 20250925: time.sleep(0.6)這句代碼會阻塞整個主线程, 導致雙擊功能會有一點點的錄音延遲，不爽。
+        # 思路1: 把整組 pause_other_audio 相關的代碼放到 task = asyncio.run_coroutine_threadsafe(send_audio(),Cosmic.loop,) 的後面, 從而避免影響接收聲音。 為方便測試調整為10秒"time.sleep(10.6)", 測試結果: 是可行的。
+            # 1. 如果我把按鍵抬起的時間放在10秒後: 功能正常, ✔會恢復播放
+            # 2. 如果我把按鍵抬起的時間放在10秒內: 功能正常, ✔不會恢復播放, 但是有一點副作用就是必須"10秒"後才會恢復運行後面的代碼
+                # 這個副作用是可以接受，因此現在採用此辦法
+
+        # 思路2: 採用异步async def delay_pause(), 為方便測試調整為10秒"asyncio.sleep(10.5)", 測試結果:
+            # 1. 如果我把按鍵抬起的時間放在10秒後: 功能正常, ✔會恢復播放
+            # 2. 如果我把按鍵抬起的時間放在10秒內: 功能正常, ✘不會恢復播放
+                # 現在不採用異步的方法, 除非有辦法能解決短時間內抬起，不會恢復播放的問題
+
+        
     # 开始任务时播放提示音
     import shutil
 
@@ -146,25 +250,44 @@ def launch_task():
         mute_all_sessions()
 
     # 录音时暂停其他音频播放 且 有音频正在播放
-    global restore_audio_playing_needed, saved_result_for_restore_audio_playing_needed
+    global restore_audio_playing_needed, saved_result_for_restore_audio_playing_needed, process_name
     if Config.pause_other_audio and not restore_audio_playing_needed:
+
         # 针对双击导致停止和播放的指令过快的问题，增加了时间延迟
         if is_short_duration:
-                # 试过的时间: 0.2✘; 0.3✘; 0.4✘; 0.5✔;1✔
-                time.sleep(0.6)
-                
-        if process_name := audio_playering_app_name():
-            if process_name != "ffplay.exe" :
-                keyboard.send("play/pause")
-                restore_audio_playing_needed  = True
+            # 用异步任务执行延迟，不阻塞当前线程
+            async def delay_pause():
+                global restore_audio_playing_needed, saved_result_for_restore_audio_playing_needed, process_name
 
-            if not is_short_duration:
-                saved_result_for_restore_audio_playing_needed = restore_audio_playing_needed
+                await asyncio.sleep(0.6)  # 异步延迟，不影响录音
 
-    # 恢復原狀：修復因 "saved_result_for_restore_audio_playing_needed" 變量導致播放器誤播的狀況(在已經本身停播的情況下)。
-    if process_name is None and not Config.hold_mode:
-        saved_result_for_restore_audio_playing_needed = False
-        restore_audio_playing_needed = False
+                if process_name := audio_playering_app_name():
+                    if process_name != "ffplay.exe":
+                        keyboard.send("play/pause")
+                        restore_audio_playing_needed = True
+
+                if process_name is None:
+                    # 恢復原狀：修復因 "saved_result_for_restore_audio_playing_needed" 變量導致播放器誤播的狀況(在已經本身停播的情況下)。
+                    saved_result_for_restore_audio_playing_needed = False
+                    restore_audio_playing_needed = False
+
+            # 启动异步任务，放入事件循环
+            asyncio.run_coroutine_threadsafe(delay_pause(), Cosmic.loop)
+
+        # 适用于非双击的情况
+        if not is_short_duration:
+            if process_name := audio_playering_app_name():
+                if process_name != "ffplay.exe" :
+                    keyboard.send("play/pause")
+                    restore_audio_playing_needed  = True
+
+            saved_result_for_restore_audio_playing_needed = restore_audio_playing_needed
+
+            # 恢復原狀：修復因 "saved_result_for_restore_audio_playing_needed" 變量導致播放器誤播的狀況(在已經本身停播的情況下)。
+            if process_name is None and not Config.hold_mode:
+                saved_result_for_restore_audio_playing_needed = False
+                restore_audio_playing_needed = False
+
 
     # 通知录音线程可以向队列放数据了
     Cosmic.on = t1
@@ -178,7 +301,7 @@ def launch_task():
         send_audio(),
         Cosmic.loop,
     )
-
+"""
 
 def cancel_task():
     # 通知停止录音，关掉滚动条

--- a/util/client_shortcut_handler.py
+++ b/util/client_shortcut_handler.py
@@ -31,6 +31,8 @@ hold_mode_first_time_cancel_task = False
 last_time_pressed = 0
 last_time_released = 0
 key_pressed = False
+saved_result_for_offline_translate_needed = False
+saved_result_for_online_translate_needed = False
 sessions = []
 
 
@@ -277,10 +279,10 @@ def click_mode(e: keyboard.KeyboardEvent):
 
     # 4. 为了解决在 Windows 下按键会自动重复的问题 : key_pressed 变量用于追踪按键是否已经被按下并记录时间。当按键第一次被按下时，记录时间并将 key_pressed 设为 True，防止重复记录时间。当按键释放时，将 key_pressed 重新设为 False，允许下一次按键记录新的时间。
     
-    # -[x] 20250918: click_mode : "double_clicked" 变量 在此处函数中 改为常駐, 他会导致 Config.enable_double_click_opposite_state 这个配置项失效， 需要修正
+    # - [x] 20250918: click_mode : "double_clicked" 变量 在此处函数中 改为常駐, 他会导致 Config.enable_double_click_opposite_state 这个配置项失效， 需要修正
             # 解决方法: client_recv_result.py : 把判断变量的位置改放在 async def recv_result() 后面。 同时把 client_shortcut_handler.py 里面的所有Config.enable_double_click_opposite_state 取消掉 。 
 
-    # -[x] Bug4: 20250919: click_mode : "Shift + double_clicked or double_clicked" 有機會導致恢復音頻播放失敗.. 原因不明，需要再跟进。 觀察: 先是停下播放之後，然後輸出文字後聽到一些聲音，但是很快就又停止了。 
+    # - [x] Bug4: 20250919: click_mode : "Shift + double_clicked or double_clicked" 有機會導致恢復音頻播放失敗.. 原因不明，需要再跟进。 觀察: 先是停下播放之後，然後輸出文字後聽到一些聲音，但是很快就又停止了。 
             # 解决方法-Bug4: 函数: "elif (double_clicked and is_short_duration)" : 這裏的函數 "restore_audio_playing()" 不應該加進來，不需要。 
     global \
         last_time_pressed, \
@@ -549,21 +551,24 @@ def _handle_key_up(last_time_pressed, is_short_duration):
 
 def hold_mode(e: keyboard.KeyboardEvent):
     """像对讲机一样，按下录音，松开停止"""
-    # -[x] 改進: 20250918: 增加了 key_pressed 变量用于追踪按键是否已经被按下， 以免某些函数会被重复触发。
-    # -[x] 改進: 20250918: 在此函数中, 取消了 Cosmic.on 的运用, 改为了 last_time_released & last_time_pressed 变量来进行时间的记录和计算.
+    # - [x] 改進: 20250918: 增加了 key_pressed 变量用于追踪按键是否已经被按下， 以免某些函数会被重复触发。
+    # - [x] 改進: 20250918: 在此函数中, 取消了 Cosmic.on 的运用, 改为了 last_time_released & last_time_pressed 变量来进行时间的记录和计算.
 
-    # -[x] Bug1: 20250918: 在Hold Mode下, 1. 如果按下和弹起`錄音鍵` 单次的時間小于< Config.threshold 以及 2.双击的功能, 会导致播放中的浏览器或者音乐播放器 *不会恢复播放* 的状态。
-        # -[x]  解決方法-Bug1 20250919: 2.双击的功能: 不会回复播放的原因是因为第一次弹起來的時候, 恢復播放的时候会有一段空档期, 这段期间使用电平侦测-是否有应用在播放的方法就会失效。 解決方法是增加了 saved_result_for_restore_audio_playing_needed 变量来保存第一次的状态。 
-        # -[x]  解決方法-Bug1 20250919: 1.小于< Config.threshold: 单次按下和弹起录音键 ， 就会快速的停止和恢复播放。但是这两个指令间隔的时间太短，导致恢复的命令被吞掉了，所以把恢复的命令放到最后，让他有更多的时间执行。 同时`def cancel_task()` 和 `def finish_task()` 里面的恢复播放命令被取消了，放到独立的函數里执行。 
+    # - [x] Bug1: 20250918: 在Hold Mode下, 1. 如果按下和弹起`錄音鍵` 单次的時間小于< Config.threshold 以及 2.双击的功能, 会导致播放中的浏览器或者音乐播放器 *不会恢复播放* 的状态。
+        # - [x]  解決方法-Bug1 20250919: 2.双击的功能: 不会回复播放的原因是因为第一次弹起來的時候, 恢復播放的时候会有一段空档期, 这段期间使用电平侦测-是否有应用在播放的方法就会失效。 解決方法是增加了 saved_result_for_restore_audio_playing_needed 变量来保存第一次的状态。 
+        # - [x]  解決方法-Bug1 20250919: 1.小于< Config.threshold: 单次按下和弹起录音键 ， 就会快速的停止和恢复播放。但是这两个指令间隔的时间太短，导致恢复的命令被吞掉了，所以把恢复的命令放到最后，让他有更多的时间执行。 同时`def cancel_task()` 和 `def finish_task()` 里面的恢复播放命令被取消了，放到独立的函數里执行。 
 
-    # -[!] Bug2: 20250918: 在上述的改动后 ，需要继续观察是否还会存在"任务顺序错乱"的情况。
-    # -[ ] Bug3: 20250918: holdmode = true: shift + 录音键(双击) 失效了, 变成了输出简体中文 。 holdmode = false: 正常。
-        # 解決方法-Bug3: 20250919: Config.enable_double_click_opposite_state= false: 修改成这个之后，他居然可以使用 "shift +双击" = 英文输出了
+    # - [?] Bug2: 20250918: 在上述的改动后 ，需要继续观察是否还会存在"任务顺序错乱"的情况。
+    # - [x] Bug3: 20250918: holdmode = true: shift + 录音键(双击) 失效了, 变成了输出简体中文 。 holdmode = false: 正常。
+        # 解決方法-Bug3: 20250919: Config.enable_double_click_opposite_state= false: 修改成这个之后，他居然可以使用 "shift +双击" = 英文输出了 (没有删除这个变量"enable_double_click_opposite_state"之前)
         # 解決方法-Bug3: 20250919: 把 hold_mode() 里面的 Config.enable_double_click_opposite_state 删除掉, "shift +双击" = 中文输出， 看来BUG和这个 enable_double_click_opposite_state 有关， 需要继续解决。 (click_mode 没有这个问题)
+        # 解決方法-Bug3: 20250924: 第二次按键抬起之前还"T3. offline_translate_needed:True", 第二次按键抬起之后"O1. offline_translate_needed:False", 完全不知道为什么有这个转变，因为这两个行动之间是没有任何关于"offline_translate_needed"的行动, 哪怕有转变之后再侦测一次"translate_needed()" 依然是"offline_translate_needed:False", 像是"shift按键" 被强行抬起了一样。 解决方法是引入"saved_result_for_offline_translate_needed"的变量储存第一次的状态。 
+        # - [?] 原因-Bug3: 20250924: 第一次按键抬起来的时候就会触发"恢复大小字母按键 keyboard.send(Config.speech_recognition_shortcut)" ， 导致该按键会被抬起，从而不能识别为按下, 因此，从这个动作之后的"translate_needed()"就会一直被认为没有按下"shift"。 20250924: 再想了想, 这个原因应该是不对的， 因为抬起的应该是"cap lock", 除非他會牵连這個 shift 按鍵？20250924: 这个牵连是有可能的, 因为 "shift" 键 = 临时切换大小写状态。 需要再继续寻找原因。。。
 
-    # -[ ] 更新 20250919: 需要更新最新版本的 "sherpa-onnx-sense-voice-zh-en-ja-ko-yue-int8-2025-09-09"
+    # - [x] 更新 20250919: 需要更新最新版本的 "sherpa-onnx-sense-voice-zh-en-ja-ko-yue-int8-2025-09-09"
+        # 解決方法-更新: 20250924: 更新成功了, 但是沒發現這個新模型有標點功能，因此需要加載額外的標點功能模型 。 最終的感覺不如舊的模型好，因此還原 。 
 
-    # -[!] Bug5: 20250919: hold_mode: 录音键(双击) 有機會導致不會恢復播放(原本已在播放)
+    # - [?] Bug5: 20250919: hold_mode: 录音键(双击) 有機會導致不會恢復播放(原本已在播放)
         # 解決方法-Bug5: def launch_task(): "# 录音时暂停其他音频播放 且 有音频正在播放" 放回到中間之後, 只測試出一次沒有恢復播放的情況。 需要繼續觀察.. 
     global \
         task, \
@@ -574,17 +579,19 @@ def hold_mode(e: keyboard.KeyboardEvent):
         hold_mode_first_time_cancel_task, \
         is_short_duration, \
         restore_audio_playing_needed, \
-        saved_result_for_restore_audio_playing_needed
+        saved_result_for_restore_audio_playing_needed, \
+        saved_result_for_offline_translate_needed, \
+        saved_result_for_online_translate_needed
     
     # 处理按键按下事件
     if e.event_type == "down":
         if not key_pressed:
             key_pressed = True  # 标记为已按下
             print(f"1. restore_audio_playing_needed:{restore_audio_playing_needed}")
+            print(f"T1. offline_translate_needed:{Cosmic.offline_translate_needed}")
             last_time_pressed = time.time()
             # 計算是否屬於短時間內按下`錄音鍵`
             is_short_duration = (last_time_pressed - last_time_released) < Config.threshold
-
 
             # 短時間內,按下第二次錄音鍵判定爲需要輸出 `簡/繁`
             if is_short_duration:
@@ -597,6 +604,7 @@ def hold_mode(e: keyboard.KeyboardEvent):
                 Cosmic.opposite_state = not Cosmic.opposite_state
 
             translate_needed()
+            print(f"T2. offline_translate_needed:{Cosmic.offline_translate_needed}")
             send_signal_to_hint_while_recording(
                 True,
                 is_short_duration,
@@ -606,10 +614,18 @@ def hold_mode(e: keyboard.KeyboardEvent):
             )
             # 启动录音任务
             launch_task()
+            saved_result_for_offline_translate_needed = Cosmic.offline_translate_needed
+            saved_result_for_online_translate_needed = Cosmic.online_translate_needed
+            print(f"T3. offline_translate_needed:{Cosmic.offline_translate_needed}")
 
     elif e.event_type == "up":
         # 仅在已按下状态时处理松开事件
         if key_pressed:
+            print(f"O1. offline_translate_needed:{Cosmic.offline_translate_needed}")
+            if is_short_duration:
+                Cosmic.offline_translate_needed = saved_result_for_offline_translate_needed
+                Cosmic.online_translate_needed = saved_result_for_online_translate_needed
+                print(f"O1A. offline_translate_needed:{Cosmic.offline_translate_needed}")
             # 标记最后弹起的时间
             last_time_released = time.time()
             # 计算按键弹起来和按下的间隔
@@ -618,9 +634,13 @@ def hold_mode(e: keyboard.KeyboardEvent):
             if duration < Config.threshold and not double_clicked:
                 hold_mode_first_time_cancel_task = True
                 cancel_task()
+                print(f"O2. offline_translate_needed:{Cosmic.offline_translate_needed}")
 
             else:
+                # translate_needed()
+                # Cosmic.offline_translate_needed = True
                 finish_task()
+                print(f"O3. offline_translate_needed:{Cosmic.offline_translate_needed}")
                 # 任务完成后, 还原释放案件的时间, 以免两个任务的时间间隔太短导致误判
                 last_time_released = 0
                 # 松开快捷键后，再按一次，恢复 CapsLock 或 Shift 等按键的状态
@@ -630,8 +650,10 @@ def hold_mode(e: keyboard.KeyboardEvent):
                 # 恢复輸出 `簡/繁` 原来的狀態
                 #if Config.enable_double_click_opposite_state:
                 double_clicked = False
+                saved_result_for_offline_translate_needed = False
+                saved_result_for_online_translate_needed = False
 
-            # 20250918: 这里不应该向 AHK 发送 is_short_duration=True 的信号, 否则会导致"语音输入中"的提示不会进行取消 (跟AHK代码逻辑有关)， 最后，不影响AHK的提示。 
+            # 20250918: 增加了"key_pressed" 之后这里不应该向 AHK 发送 is_short_duration=True 的信号, 否则会导致"语音输入中"的提示不会进行取消 (跟AHK代码逻辑有关)， 最后，不影响AHK的提示。 
             send_signal_to_hint_while_recording(
                 False,
                 False,
@@ -642,6 +664,7 @@ def hold_mode(e: keyboard.KeyboardEvent):
             # 恢復音频的播放
             restore_audio_playing()
             key_pressed = False  # 标记为未按下
+            print(f"O4. offline_translate_needed:{Cosmic.offline_translate_needed}")
             print(f"Last. restore_audio_playing_needed:{restore_audio_playing_needed}")
 
 # ==================== 绑定 handler ===============================

--- a/util/client_shortcut_handler.py
+++ b/util/client_shortcut_handler.py
@@ -150,8 +150,8 @@ def launch_task():
     if Config.pause_other_audio and not restore_audio_playing_needed:
         # 针对双击导致停止和播放的指令过快的问题，增加了时间延迟
         if is_short_duration:
-                # 试过的时间: 0.2✘; 0.3✘; 0.4✔; 0.5✔;1✔
-                time.sleep(0.4)
+                # 试过的时间: 0.2✘; 0.3✘; 0.4✘; 0.5✔;1✔
+                time.sleep(0.6)
                 
         if process_name := audio_playering_app_name():
             if process_name != "ffplay.exe" :
@@ -423,8 +423,9 @@ def hold_mode(e: keyboard.KeyboardEvent):
             )
             # 启动录音任务
             launch_task()
-            saved_result_for_offline_translate_needed = Cosmic.offline_translate_needed
-            saved_result_for_online_translate_needed = Cosmic.online_translate_needed
+            if not is_short_duration:
+                saved_result_for_offline_translate_needed = Cosmic.offline_translate_needed
+                saved_result_for_online_translate_needed = Cosmic.online_translate_needed
 
     elif e.event_type == "up":
         # 仅在已按下状态时处理松开事件

--- a/util/client_shortcut_handler.py
+++ b/util/client_shortcut_handler.py
@@ -33,6 +33,7 @@ last_time_released = 0
 key_pressed = False
 saved_result_for_offline_translate_needed = False
 saved_result_for_online_translate_needed = False
+unmute_task = None
 sessions = []
 
 
@@ -72,15 +73,31 @@ def unmute_all_sessions():
             volume.SetMute(0, None)
 
 
+# 封装需要异步执行的逻辑（延迟+取消静音）
+async def async_unmute_after_delay():
+    # 异步延迟0.3秒（不阻塞事件循环）
+    await asyncio.sleep(0.3)
+    # 执行取消静音操作
+    unmute_all_sessions()
+
+
 def restore_audio_playing():
+    # - [x] 改進: 20250925: 把 "cancel_task()" 和 "finish_task()" 裏面的恢復音頻音量的函數"unmute_all_sessions()"全放在這裏, 同时，采用了异步 + 延迟的方法，避免了阻塞主线程，以及避免一些"杂音"。
+
     # 恢復音频的播放
-    global restore_audio_playing_needed, saved_result_for_restore_audio_playing_needed
+    global restore_audio_playing_needed, saved_result_for_restore_audio_playing_needed, unmute_task
     # 处理音频暂停相关逻辑
     restore_audio_playing_needed = saved_result_for_restore_audio_playing_needed
 
     if Config.pause_other_audio and restore_audio_playing_needed:
         keyboard.send("play/pause")
         restore_audio_playing_needed  = False
+
+    # 取消音频静音, 在主线程中调用（非事件循环线程）, 这行代码会立即返回，不会阻塞主线程
+    unmute_task = asyncio.run_coroutine_threadsafe(
+        async_unmute_after_delay(),  # 提交封装好的异步任务
+        Cosmic.loop  # 目标事件循环
+    )
 
 
 def translate_needed():
@@ -104,10 +121,12 @@ def translate_needed():
 # 這個函數採用了: 把整組 pause_other_audio 相關的代碼放到 task = asyncio.run_coroutine_threadsafe(send_audio(),Cosmic.loop,) 的後面, 從而避免影響接收聲音。
 def launch_task():
     # - [x] 改進點: 20250925: time.sleep(0.6)這句代碼會阻塞整個主线程, 導致雙擊功能會有一點點的錄音延遲，不爽。
-        # 思路1: 把整組 pause_other_audio 相關的代碼放到 task = asyncio.run_coroutine_threadsafe(send_audio(),Cosmic.loop,) 的後面, 從而避免影響接收聲音。 為方便測試調整為10秒"time.sleep(10.6)", 測試結果: 是可行的。
+        # ✔思路1: 把整組 pause_other_audio 相關的代碼放到 task = asyncio.run_coroutine_threadsafe(send_audio(),Cosmic.loop,) 的後面, 從而避免影響接收聲音。 為方便測試調整為10秒"time.sleep(10.6)", 測試結果: 是可行的。
             # 1. 如果我把按鍵抬起的時間放在10秒後: 功能正常, ✔會恢復播放
-            # 2. 如果我把按鍵抬起的時間放在10秒內: 功能正常, ✔不會恢復播放, 但是有一點副作用就是必須"10秒"後才會恢復運行後面的代碼
+            # 2. 如果我把按鍵抬起的時間放在10秒內: 功能正常, ✔會恢復播放, 但是有一點副作用就是必須"10秒"後才會恢復運行後面的代碼
                 # 這個副作用是可以接受，因此現在採用此辦法
+                # - Bug: 在應用程式全部暫停播放的情況下使用錄音會導致播放的情況
+                # - 只在hold_mode的情況出現, 是 "and not Config.hold_mode" 的判斷問題
 
         # 思路2: 採用异步async def delay_pause(), 為方便測試調整為10秒"asyncio.sleep(10.5)", 測試結果:
             # 1. 如果我把按鍵抬起的時間放在10秒後: 功能正常, ✔會恢復播放
@@ -121,7 +140,7 @@ def launch_task():
 
         play_music(Config.start_music_path, Config.start_music_volume)
 
-    global hold_mode_first_time_cancel_task
+    global hold_mode_first_time_cancel_task, unmute_task
     # 确认是否需要翻译
     # 改为独立调用
     # translate_needed()
@@ -151,6 +170,14 @@ def launch_task():
     asyncio.run_coroutine_threadsafe(
         Cosmic.queue_in.put({"type": "begin", "time": t1, "data": None}), Cosmic.loop
     )
+
+    if is_short_duration and unmute_task is not None:
+        is_cancelled = unmute_task.cancel()
+        # if is_cancelled:
+        #     print("成功取消延迟的unmute操作")
+        # else:
+        #     print("取消失败（任务可能已执行或已完成）")
+        unmute_task = None
 
     # 录音时静音其他音频播放
     if Config.mute_other_audio:
@@ -195,10 +222,12 @@ def launch_task():
 # 這個函數採用了 异步async def delay_pause()
 def launch_task():
     # - [x] 改進點: 20250925: time.sleep(0.6)這句代碼會阻塞整個主线程, 導致雙擊功能會有一點點的錄音延遲，不爽。
-        # 思路1: 把整組 pause_other_audio 相關的代碼放到 task = asyncio.run_coroutine_threadsafe(send_audio(),Cosmic.loop,) 的後面, 從而避免影響接收聲音。 為方便測試調整為10秒"time.sleep(10.6)", 測試結果: 是可行的。
+        # ✔思路1: 把整組 pause_other_audio 相關的代碼放到 task = asyncio.run_coroutine_threadsafe(send_audio(),Cosmic.loop,) 的後面, 從而避免影響接收聲音。 為方便測試調整為10秒"time.sleep(10.6)", 測試結果: 是可行的。
             # 1. 如果我把按鍵抬起的時間放在10秒後: 功能正常, ✔會恢復播放
-            # 2. 如果我把按鍵抬起的時間放在10秒內: 功能正常, ✔不會恢復播放, 但是有一點副作用就是必須"10秒"後才會恢復運行後面的代碼
+            # 2. 如果我把按鍵抬起的時間放在10秒內: 功能正常, ✔會恢復播放, 但是有一點副作用就是必須"10秒"後才會恢復運行後面的代碼
                 # 這個副作用是可以接受，因此現在採用此辦法
+                # - Bug: 在應用程式全部暫停播放的情況下使用錄音會導致播放的情況
+                    # - 只在hold_mode的情況出現, 是這個 "and not Config.hold_mode" 的判斷問題
 
         # 思路2: 採用异步async def delay_pause(), 為方便測試調整為10秒"asyncio.sleep(10.5)", 測試結果:
             # 1. 如果我把按鍵抬起的時間放在10秒後: 功能正常, ✔會恢復播放
@@ -308,10 +337,6 @@ def cancel_task():
     Cosmic.on = False
     status.stop()
 
-   # 取消音频静音
-    if Config.mute_other_audio:
-        unmute_all_sessions()
-
     # 发送取消任务的消息到队列
     asyncio.run_coroutine_threadsafe(
         Cosmic.queue_in.put({"type": "cancel", "time": time.time(), "data": None}),
@@ -338,10 +363,6 @@ def finish_task():
         ),
         Cosmic.loop,
     )
-
-    # 取消音频静音
-    if Config.mute_other_audio:
-        unmute_all_sessions()
 
     # 结束任务时播放提示音
     import shutil


### PR DESCRIPTION
# [Hold Mode]
## 改进
增加 key_pressed 变量，避免函数重复触发。

使用 last_time_pressed/released 替代 Cosmic.on 进行时间记录。

## Bug 修复
Bug1：录音键单击/双击导致播放无法恢复 → 通过 saved_result_for_restore_audio_playing_needed 保存状态，并延迟恢复命令。
- [x]  Bug1 20250928: hold_mode换大小写的时候有极小的机会不会恢复播放的情况, 
			- 解決方法-Bug1 20250928: 引入 is_short_press 并且增加延迟时间


Bug3：shift + 双击失效，输出简体中文 → 调整 Config.enable_double_click_opposite_state 配置，并引入 saved_result_for_offline_translate_needed。

Bug5：双击后播放未恢复 → 增加延迟逻辑，仅在 hold_mode 下应用。

## 待观察
Bug2：任务顺序错乱仍需观察。

Bug3：可能与 shift/caps lock 状态牵连。

## 模型更新
更新 sherpa-onnx-sense-voice-zh-en-ja-ko-yue-int8-2025-09-09 模型 → 没发现此模型有标点符号的输出，需要额外的标点符号模型(CT-Transformer标点-中英文-通用-large)配合。这两者的最终测试中，个人主观感觉在最终输出速度稍稍慢了一点点(没有数据支持)。 暂时不更新。


# [Click Mode]
## 改进
实现长按自动切换大小写，无需抬起按键。

引入 return_allowed 变量，解决长按后立即录音失败的问题。

## Bug 修复
Bug4：双击后播放失败 → 移除 restore_audio_playing() 函数。

Bug6：double_clicked 常驻导致配置失效 → 调整变量位置并移除相关配置项。

## 潜在改善
多应用播放状态未统一暂停 → 需支持逐个判断与控制，audio_playering_app_name() 结果需存入数组。

# [launch_task]
## 改进
移除 time.sleep(0.6) 阻塞逻辑，改为延后执行暂停音频。

修复 hold_mode 下暂停判断逻辑错误（and not Config.hold_mode）。

# [restore_audio_playering]
## 改进
将 unmute_all_sessions() 移至此模块集中处理。

使用异步 + 延迟方式恢复音量，避免主线程阻塞与杂音干扰。